### PR TITLE
Prettify cli show

### DIFF
--- a/lib/gush/cli.rb
+++ b/lib/gush/cli.rb
@@ -34,6 +34,9 @@ module Gush
     end
 
     desc "show [workflow_id]", "Shows details about workflow with given ID"
+    option :skip_overview, type: :boolean
+    option :skip_jobs, type: :boolean
+    option :jobs, default: :all
     def show(workflow_id)
       require gushfile
       workflow = Gush.find_workflow(workflow_id, redis)
@@ -43,73 +46,9 @@ module Gush
         return
       end
 
-      rows = []
-      progress = ""
-      if workflow.failed?
-        status = "failed".red
-        status += "\n"
-        status += "#{workflow.nodes.find(&:failed).name} failed".red
-      elsif workflow.running?
-        status = "running".yellow
-        finished = workflow.nodes.count {|job| job.finished }
-        total = workflow.nodes.count
-        progress = "#{finished}/#{total} [#{(finished*100)/total}%]"
-      elsif workflow.finished?
-        status = "done".green
-      else
-        status = "pending".light_white
-      end
+      display_overview_for(workflow) unless options[:skip_overview]
 
-      rows << [{alignment: :center, value: "id"}, workflow.name]
-      rows << :separator
-      rows << [{alignment: :center, value: "name"}, workflow.class.to_s]
-      rows << :separator
-      rows << [{alignment: :center, value: "jobs"}, workflow.nodes.count]
-      rows << :separator
-      rows << [{alignment: :center, value: "failed jobs"}, workflow.nodes.count(&:failed?).to_s.red]
-      rows << :separator
-      rows << [{alignment: :center, value: "succeeded jobs"},
-        workflow.nodes.count { |j| j.finished && !j.failed }.to_s.green]
-      rows << :separator
-      rows << [{alignment: :center, value: "enqueued jobs"}, workflow.nodes.count(&:running?).to_s.yellow]
-      rows << :separator
-      rows << [{alignment: :center, value: "remaining jobs"},
-        workflow.nodes.count{|j| [j.finished, j.failed, j.enqueued].all? {|b| !b} }]
-      rows << :separator
-      rows << [{alignment: :center, value: "status"}, status]
-      if !progress.empty?
-        rows << :separator
-        rows << [{alignment: :center, value: "progress"}, progress]
-      end
-      table = Terminal::Table.new(rows: rows)
-      puts table
-
-      puts "\nJobs list:\n"
-
-      workflow.nodes.sort_by do |job|
-        case
-        when job.failed?
-          0
-        when job.finished?
-          1
-        when job.running?
-          2
-        else
-          3
-        end
-      end.each do |job|
-        name = job.name
-        puts case
-        when job.failed?
-          "[✗] #{name.red}"
-        when job.finished?
-          "[✓] #{name.green}"
-        when job.running?
-          "[•] #{name.yellow}"
-        else
-          "[ ] #{name}"
-        end
-      end
+      display_jobs_list_for(workflow, options[:jobs]) unless options[:skip_jobs]
     end
 
 
@@ -209,6 +148,84 @@ module Gush
 
     def redis
       @redis ||= Redis.new
+    end
+
+    def display_overview_for(workflow)
+      rows = []
+      progress = ""
+      if workflow.failed?
+        status = "failed".red
+        status += "\n"
+        status += "#{workflow.nodes.find(&:failed).name} failed".red
+      elsif workflow.running?
+        status = "running".yellow
+        finished = workflow.nodes.count {|job| job.finished }
+        total = workflow.nodes.count
+        progress = "#{finished}/#{total} [#{(finished*100)/total}%]"
+      elsif workflow.finished?
+        status = "done".green
+      else
+        status = "pending".light_white
+      end
+
+      rows << [{alignment: :center, value: "id"}, workflow.name]
+      rows << :separator
+      rows << [{alignment: :center, value: "name"}, workflow.class.to_s]
+      rows << :separator
+      rows << [{alignment: :center, value: "jobs"}, workflow.nodes.count]
+      rows << :separator
+      rows << [{alignment: :center, value: "failed jobs"}, workflow.nodes.count(&:failed?).to_s.red]
+      rows << :separator
+      rows << [{alignment: :center, value: "succeeded jobs"},
+        workflow.nodes.count { |j| j.finished && !j.failed }.to_s.green]
+      rows << :separator
+      rows << [{alignment: :center, value: "enqueued jobs"}, workflow.nodes.count(&:running?).to_s.yellow]
+      rows << :separator
+      rows << [{alignment: :center, value: "remaining jobs"},
+        workflow.nodes.count{|j| [j.finished, j.failed, j.enqueued].all? {|b| !b} }]
+      rows << :separator
+      rows << [{alignment: :center, value: "status"}, status]
+      if !progress.empty?
+        rows << :separator
+        rows << [{alignment: :center, value: "progress"}, progress]
+      end
+      puts Terminal::Table.new(rows: rows)
+    end
+
+    def display_jobs_list_for(workflow, jobs)
+      puts "\nJobs list:\n"
+
+      jobs_by_type(workflow, jobs).each do |job|
+        name = job.name
+        puts case
+        when job.failed?
+          "[✗] #{name.red}"
+        when job.finished?
+          "[✓] #{name.green}"
+        when job.running?
+          "[•] #{name.yellow}"
+        else
+          "[ ] #{name}"
+        end
+      end
+    end
+
+    def jobs_by_type(workflow, type)
+      jobs = workflow.nodes.sort_by do |job|
+        case
+        when job.failed?
+          0
+        when job.finished?
+          1
+        when job.running?
+          2
+        else
+          3
+        end
+      end
+
+      jobs.select!{|j| j.public_send("#{type}?") } unless type == :all
+      jobs
     end
   end
 end


### PR DESCRIPTION
Few sweet changes in `gush show` command:
- Added indicators to job names to determine its state when terminal cannot into colors.
- Added ability to skip overview by --skip-overview option
- Added ability to skip jobs list by --skip-jobs option
- Added ability to filter jobs type in jobs list by --jobs (all|running|done|failed) option
