### PR TITLE
Update CLI gushfile method to use configuration

### DIFF
--- a/lib/gush/cli.rb
+++ b/lib/gush/cli.rb
@@ -126,7 +126,7 @@ module Gush
     end
 
     def gushfile
-      Pathname.pwd.join(options[:gushfile])
+      Gush.configuration.gushfile
     end
 
     def load_gushfile


### PR DESCRIPTION
CLI class build configuration hash basing on given options or default values. In this manner we can require Gushfile from configuration path instead of relying on options which might not be passed.