### PR TITLE
Fixed typographical error, changed availabe to available in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ end
 
 #### Passing arguments to workflows
 
-Workflows can accept any primitive arguments in their constructor, which then will be availabe in your
+Workflows can accept any primitive arguments in their constructor, which then will be available in your
 `configure` method.
 
 Here's an example of a workflow responsible for publishing a book:


### PR DESCRIPTION
chaps-io, I've corrected a typographical error in the documentation of the [gush](https://github.com/chaps-io/gush) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.