### PR TITLE
Assign unique names for jobs with the same class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 gem 'pry'
 gem 'yajl-ruby'
+gem 'rspec-json_expectations'
 gem "fakeredis", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ gemspec
 
 gem 'pry'
 gem 'yajl-ruby'
-gem 'rspec-json_expectations'
 gem "fakeredis", require: false

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -99,8 +99,13 @@ module Gush
 
     def load_job(workflow_id, job_id)
       workflow = find_workflow(workflow_id)
-      data = redis.get("gush.jobs.#{workflow_id}.#{job_id}")
-      return nil if data.nil?
+
+      keys = redis.keys("gush.jobs.#{workflow_id}.#{job_id}*")
+      return nil if keys.nil?
+
+      data = redis.get(keys.first)
+      return nil if keys.nil?
+
       data = Gush::JSON.decode(data, symbolize_keys: true)
       Gush::Job.from_hash(workflow, data)
     end

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -46,11 +46,21 @@ module Gush
       persist_workflow(workflow)
     end
 
-    def next_free_id
+    def next_free_job_id(workflow_id,job_class)
       id = nil
       loop do
         id = SecureRandom.uuid
-        break if !redis.exists("gush.workflow.#{id}")
+        break if !redis.exists("gush.jobs.#{workflow_id}.#{job_class}-#{id}")
+      end
+
+      "#{job_class}-#{id}"
+    end
+
+    def next_free_workflow_id
+      id = nil
+      loop do
+        id = SecureRandom.uuid
+        break if !redis.exists("gush.workflow.#{id}.")
       end
 
       id
@@ -118,7 +128,7 @@ module Gush
       sidekiq.push(
         'class' => Gush::Worker,
         'queue' => configuration.namespace,
-        'args'  => [workflow_id, job.class.to_s]
+        'args'  => [workflow_id, job.name]
       )
     end
 

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -145,6 +145,7 @@ module Gush
     def workflow_from_hash(hash, nodes = nil)
       flow = hash[:klass].constantize.new
       flow.stopped = hash.fetch(:stopped, false)
+      flow.nameize_payloads = hash[:nameize_payloads]
       flow.id = hash[:id]
 
       (nodes || hash[:nodes]).each do |node|

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -93,12 +93,14 @@ module Gush
     end
 
     def persist_job(workflow_id, job)
-      redis.set("gush.jobs.#{workflow_id}.#{job.class.to_s}", job.to_json)
+      puts "Persisting job with name: #{job.name}"
+      redis.set("gush.jobs.#{workflow_id}.#{job.name}", job.to_json)
     end
 
     def load_job(workflow_id, job_id)
       workflow = find_workflow(workflow_id)
       data = redis.get("gush.jobs.#{workflow_id}.#{job_id}")
+      puts "#{data.inspect}"
       return nil if data.nil?
       data = Gush::JSON.decode(data, symbolize_keys: true)
       Gush::Job.from_hash(workflow, data)
@@ -110,7 +112,7 @@ module Gush
     end
 
     def destroy_job(workflow_id, job)
-      redis.del("gush.jobs.#{workflow_id}.#{job.class.to_s}")
+      redis.del("gush.jobs.#{workflow_id}.#{job.name}")
     end
 
     def worker_report(message)

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -1,7 +1,7 @@
 module Gush
   class Job
     attr_accessor :workflow_id, :incoming, :outgoing, :params,
-      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads
+      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads, :payloads_hash, :klass
     attr_reader :name, :output_payload, :params
 
     def initialize(workflow, opts = {})
@@ -35,6 +35,12 @@ module Gush
 
     def output(data)
       @output_payload = data
+    end
+
+    def payloads
+      pls = {}
+      payloads_hash.each {|k,val| pls[k.to_s] = val.map {|h| h[:payload] }}
+      pls
     end
 
     def work
@@ -111,6 +117,7 @@ module Gush
       @started_at     = opts[:started_at]
       @enqueued_at    = opts[:enqueued_at]
       @params         = opts[:params] || {}
+      @klass          = opts[:klass]
       @output_payload = opts[:output_payload]
     end
   end

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -1,8 +1,8 @@
 module Gush
   class Job
     attr_accessor :workflow_id, :incoming, :outgoing, :params,
-      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads, :payloads_hash, :klass
-    attr_reader :name, :output_payload, :params
+      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads_hash, :klass
+    attr_reader :name, :output_payload, :params, :payloads
 
     def initialize(workflow, opts = {})
       @workflow = workflow

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -38,9 +38,9 @@ module Gush
     end
 
     def payloads
-      pls = {}
-      payloads_hash.each {|k,val| pls[k.to_s] = val.map {|h| h[:payload] }}
-      pls
+      payload_h = {}
+      payloads_hash.each {|k,val| payload_h[k.to_s] = val.map {|h| h[:payload] }}
+      payload_h
     end
 
     def work

--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -9,7 +9,7 @@ module Gush
     def perform(workflow_id, job_id)
       setup_job(workflow_id, job_id)
 
-      job.payloads = incoming_payloads
+      job.payloads_hash = incoming_payloads
 
       start = Time.now
       report(:started, start)
@@ -52,18 +52,9 @@ module Gush
       payloads = {}
       job.incoming.each do |job_name|
        job = client.load_job(workflow.id, job_name)
-       payloads[job.class.to_s] ||= []
-
-       if workflow.nameize_payloads
-         payload = {:id => job.name, :payload => job.output_payload}
-       else
-         payload = job.output_payload
-       end
-       unless payload.nil?
-         payloads[job.class.to_s] << payload
-       end
+       payloads[job.klass.to_s] ||= []
+       payloads[job.klass.to_s] << {:id => job.name, :payload => job.output_payload}
       end
-
       payloads
     end
 

--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -44,14 +44,18 @@ module Gush
     end
 
     def setup_job(workflow_id, job_id)
+      puts '=========================================='
+      puts "searching for #{job_id} in #{workflow_id} workflow space"
       @workflow ||= client.find_workflow(workflow_id)
       @job ||= workflow.find_job(job_id)
+      puts "Job found with name: #{job.name.inspect}"
+      puts '=========================================='
     end
 
     def incoming_payloads
       payloads = {}
       job.incoming.each do |job_name|
-        payloads[job_name] = client.load_job(workflow.id, job_name).output_payload
+       payloads[job_name] = client.load_job(workflow.id, job_name).output_payload
       end
 
       payloads

--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -44,18 +44,23 @@ module Gush
     end
 
     def setup_job(workflow_id, job_id)
-      puts '=========================================='
-      puts "searching for #{job_id} in #{workflow_id} workflow space"
       @workflow ||= client.find_workflow(workflow_id)
       @job ||= workflow.find_job(job_id)
-      puts "Job found with name: #{job.name.inspect}"
-      puts '=========================================='
     end
 
     def incoming_payloads
       payloads = {}
       job.incoming.each do |job_name|
-       payloads[job_name] = client.load_job(workflow.id, job_name).output_payload
+       job = client.load_job(workflow.id, job_name)
+       payloads[job.class.to_s] ||= []
+       if workflow.nameize_payloads?
+         payload = {:id => job.name, :payload => job.output_payload}
+       else
+         payload = job.output_payload
+       end
+       unless payload.nil?
+         payloads[job.class.to_s] << payload
+       end
       end
 
       payloads

--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -53,7 +53,8 @@ module Gush
       job.incoming.each do |job_name|
        job = client.load_job(workflow.id, job_name)
        payloads[job.class.to_s] ||= []
-       if workflow.nameize_payloads?
+
+       if workflow.nameize_payloads
          payload = {:id => job.name, :payload => job.output_payload}
        else
          payload = job.output_payload

--- a/lib/gush/workflow.rb
+++ b/lib/gush/workflow.rb
@@ -63,7 +63,7 @@ module Gush
     end
 
     def find_job(name)
-      jobs.find { |node| node.name.to_s == name.to_s || node.class.to_s == name.to_s }
+      jobs.find { |node| node.name.to_s == name.to_s }
     end
 
     def finished?
@@ -98,12 +98,12 @@ module Gush
 
       deps_after = [*opts[:after]]
       deps_after.each do |dep|
-        @dependencies << {from: dep.name, to: node.name }
+        @dependencies << {from: dep, to: node.name }
       end
 
       deps_before = [*opts[:before]]
       deps_before.each do |dep|
-        @dependencies << {from: node.name, to: dep.name }
+        @dependencies << {from: node.name, to: dep }
       end
 
       node.name

--- a/lib/gush/workflow.rb
+++ b/lib/gush/workflow.rb
@@ -57,10 +57,6 @@ module Gush
       @nameize_payloads = true
     end
 
-    def nameize_payloads?
-      @nameize_payloads
-    end
-
     def resolve_dependencies
       @dependencies.each do |dependency|
         from = find_job(dependency[:from])
@@ -72,7 +68,7 @@ module Gush
     end
 
     def find_job(name)
-      match_data = /(?<klass>\w*[^-])-(?<identifier>.*)/.match(name)
+      match_data = /(?<klass>\w*[^-])-(?<identifier>.*)/.match(name.to_s)
       if match_data.nil?
         job = jobs.find { |node| node.class.to_s == name.to_s }
       else
@@ -168,7 +164,8 @@ module Gush
         status: status,
         stopped: stopped,
         started_at: started_at,
-        finished_at: finished_at
+        finished_at: finished_at,
+        nameize_payloads: nameize_payloads
       }
     end
 

--- a/lib/gush/workflow.rb
+++ b/lib/gush/workflow.rb
@@ -90,7 +90,7 @@ module Gush
       options =
 
       node = klass.new(self, {
-        name: klass.to_s,
+        name: client.next_free_job_id(id,klass.to_s),
         params: opts.fetch(:params, {})
       })
 
@@ -98,13 +98,15 @@ module Gush
 
       deps_after = [*opts[:after]]
       deps_after.each do |dep|
-        @dependencies << {from: dep.to_s, to: klass.to_s }
+        @dependencies << {from: dep.name, to: node.name }
       end
 
       deps_before = [*opts[:before]]
       deps_before.each do |dep|
-        @dependencies << {from: klass.to_s, to: dep.to_s }
+        @dependencies << {from: node.name, to: dep.name }
       end
+
+      return node.name
     end
 
     def reload
@@ -164,7 +166,7 @@ module Gush
     end
 
     def id
-      @id ||= client.next_free_id
+      @id ||= client.next_free_workflow_id
     end
 
     private

--- a/lib/gush/workflow.rb
+++ b/lib/gush/workflow.rb
@@ -2,7 +2,7 @@ require 'securerandom'
 
 module Gush
   class Workflow
-    attr_accessor :id, :jobs, :stopped, :persisted, :arguments, :nameize_payloads
+    attr_accessor :id, :jobs, :stopped, :persisted, :arguments
 
     def initialize(*args)
       @id = id
@@ -11,7 +11,6 @@ module Gush
       @persisted = false
       @stopped = false
       @arguments = args
-      @nameize_payloads = false
     end
 
     def self.find(id)
@@ -51,10 +50,6 @@ module Gush
 
     def mark_as_started
       @stopped = false
-    end
-
-    def nameize_payloads!
-      @nameize_payloads = true
     end
 
     def resolve_dependencies
@@ -165,7 +160,6 @@ module Gush
         stopped: stopped,
         started_at: started_at,
         finished_at: finished_at,
-        nameize_payloads: nameize_payloads
       }
     end
 

--- a/lib/gush/workflow.rb
+++ b/lib/gush/workflow.rb
@@ -63,7 +63,7 @@ module Gush
     end
 
     def find_job(name)
-      jobs.find { |node| node.name == name.to_s || node.class.to_s == name.to_s }
+      jobs.find { |node| node.name.to_s == name.to_s || node.class.to_s == name.to_s }
     end
 
     def finished?
@@ -106,7 +106,7 @@ module Gush
         @dependencies << {from: node.name, to: dep.name }
       end
 
-      return node.name
+      node.name
     end
 
     def reload

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -52,7 +52,7 @@ describe "Workflows" do
 
     class PrependJob < Gush::Job
       def work
-        string = "#{payloads["PrefixJob"].first}: #{payloads["UpcaseJob"].first}"
+        string = "#{payloads['PrefixJob'].first}: #{payloads['UpcaseJob'].first}"
         output string
       end
     end
@@ -76,6 +76,8 @@ describe "Workflows" do
 
     Gush::Worker.perform_one
     expect(flow.reload.find_job("PrependJob").output_payload).to eq("A prefix: SOME TEXT")
+
+
   end
 
   it "passes payloads from workflow that runs multiple same class jobs with nameized payloads" do
@@ -87,13 +89,12 @@ describe "Workflows" do
 
     class SummaryJob < Gush::Job
       def work
-        output payloads["RepetitiveJob"]
+        output payloads['RepetitiveJob']
       end
     end
 
     class PayloadWorkflow < Gush::Workflow
       def configure
-        nameize_payloads!
         jobs = []
         jobs << run(RepetitiveJob, params: {input: 'first'})
         jobs << run(RepetitiveJob, params: {input: 'second'})
@@ -115,9 +116,7 @@ describe "Workflows" do
     expect(flow.reload.find_job(flow.jobs[2].name).output_payload).to eq('third')
 
     Gush::Worker.perform_one
-    output_payload = flow.reload.find_job(flow.jobs[3].name).output_payload
-    expect(output_payload[0]).to eq({:id => flow.jobs[0].name, :payload => 'first'})
-    expect(output_payload[1]).to eq({:id => flow.jobs[1].name, :payload => 'second'})
-    expect(output_payload[2]).to eq({:id => flow.jobs[2].name, :payload => 'third'})
+    expect(flow.reload.find_job(flow.jobs[3].name).output_payload).to eq(%w(first second third))
+
   end
 end

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -18,19 +18,19 @@ describe "Workflows" do
     flow = TestWorkflow.create
     flow.start!
 
-    expect(Gush::Worker).to have_jobs(flow.id, ["Prepare"])
+    expect(Gush::Worker).to have_jobs(flow.id, jobs_with_id(['Prepare']))
 
     Gush::Worker.perform_one
-    expect(Gush::Worker).to have_jobs(flow.id, ["FetchFirstJob", "FetchSecondJob"])
+    expect(Gush::Worker).to have_jobs(flow.id, jobs_with_id(["FetchFirstJob", "FetchSecondJob"]))
 
     Gush::Worker.perform_one
-    expect(Gush::Worker).to have_jobs(flow.id, ["FetchSecondJob", "PersistFirstJob"])
+    expect(Gush::Worker).to have_jobs(flow.id, jobs_with_id(["FetchSecondJob", "PersistFirstJob"]))
 
     Gush::Worker.perform_one
-    expect(Gush::Worker).to have_jobs(flow.id, ["PersistFirstJob"])
+    expect(Gush::Worker).to have_jobs(flow.id, jobs_with_id(["PersistFirstJob"]))
 
     Gush::Worker.perform_one
-    expect(Gush::Worker).to have_jobs(flow.id, ["NormalizeJob"])
+    expect(Gush::Worker).to have_jobs(flow.id, jobs_with_id(["NormalizeJob"]))
 
     Gush::Worker.perform_one
 
@@ -52,7 +52,7 @@ describe "Workflows" do
 
     class PrependJob < Gush::Job
       def work
-        string = "#{payloads["PrefixJob"]}: #{payloads["UpcaseJob"]}"
+        string = "#{payloads["PrefixJob"].first}: #{payloads["UpcaseJob"].first}"
         output string
       end
     end

--- a/spec/lib/gush/client_spec.rb
+++ b/spec/lib/gush/client_spec.rb
@@ -85,7 +85,9 @@ describe Gush::Client do
 
   describe "#persist_job" do
     it "persists JSON dump of the job in Redis" do
-      job = double("job", to_json: 'json')
+
+      job = BobJob.new(name: 'bob')
+
       client.persist_job('deadbeef', job)
       expect(redis.keys("gush.jobs.deadbeef.*").length).to eq(1)
     end

--- a/spec/lib/gush/workflow_spec.rb
+++ b/spec/lib/gush/workflow_spec.rb
@@ -66,49 +66,48 @@ describe Gush::Workflow do
           run FetchFirstJob
           run PersistFirstJob, after: FetchFirstJob
         end
-
       end
 
       result = JSON.parse(klass.create("arg1", "arg2").to_json)
       expected = {
-        "id" => an_instance_of(String),
-        "name" => klass.to_s,
-        "klass" => klass.to_s,
-        "status" => "running",
-        "total" => 2,
-        "finished" => 0,
-        "started_at" => nil,
-        "finished_at" => nil,
-        "stopped" => false,
-        "arguments" => ["arg1", "arg2"],
-        "jobs" => [
-          {
-            "name"=>an_instance_of(String),
-            "klass"=>"FetchFirstJob",
-            "incoming"=>[],
-            "outgoing"=>["PersistFirstJob"],
-            "finished_at"=>nil,
-            "started_at"=>nil,
-            "enqueued_at"=>nil,
-            "failed_at"=>nil,
-            "params" => {},
-            "output_payload" => nil
-          },
-          {
-            "name"=>an_instance_of(String),
-            "klass"=>"PersistFirstJob",
-            "incoming"=>["FetchFirstJob"],
-            "outgoing"=>[],
-            "finished_at"=>nil,
-            "started_at"=>nil,
-            "enqueued_at"=>nil,
-            "failed_at"=>nil,
-            "params" => {},
-            "output_payload" => nil
-          }
-        ]
+          "id" => an_instance_of(String),
+          "name" => klass.to_s,
+          "klass" => klass.to_s,
+          "status" => "running",
+          "total" => 2,
+          "finished" => 0,
+          "started_at" => nil,
+          "finished_at" => nil,
+          "stopped" => false,
+          "arguments" => ["arg1", "arg2"],
+          "jobs" => [
+              {
+                  "name"=>a_string_starting_with('FetchFirstJob'),
+                  "klass"=>"FetchFirstJob",
+                  "incoming"=>[],
+                  "outgoing"=>[a_string_starting_with('PersistFirstJob')],
+                  "finished_at"=>nil,
+                  "started_at"=>nil,
+                  "enqueued_at"=>nil,
+                  "failed_at"=>nil,
+                  "params" => {},
+                  "output_payload" => nil
+              },
+              {
+                  "name"=>a_string_starting_with('PersistFirstJob'),
+                  "klass"=>"PersistFirstJob",
+                  "incoming"=>["FetchFirstJob"],
+                  "outgoing"=>[],
+                  "finished_at"=>nil,
+                  "started_at"=>nil,
+                  "enqueued_at"=>nil,
+                  "failed_at"=>nil,
+                  "params" => {},
+                  "output_payload" => nil
+              }
+          ]
       }
-      expect(result).to match(a_hash_including(expected))
+      expect(result).to match(expected)
     end
   end
 

--- a/spec/lib/gush/workflow_spec.rb
+++ b/spec/lib/gush/workflow_spec.rb
@@ -80,6 +80,7 @@ describe Gush::Workflow do
           "finished_at" => nil,
           "stopped" => false,
           "arguments" => ["arg1", "arg2"],
+          "nameize_payloads" => false,
           "jobs" => [
               {
                   "name"=>a_string_starting_with('FetchFirstJob'),

--- a/spec/lib/gush/workflow_spec.rb
+++ b/spec/lib/gush/workflow_spec.rb
@@ -66,6 +66,7 @@ describe Gush::Workflow do
           run FetchFirstJob
           run PersistFirstJob, after: FetchFirstJob
         end
+
       end
 
       result = JSON.parse(klass.create("arg1", "arg2").to_json)
@@ -82,7 +83,7 @@ describe Gush::Workflow do
         "arguments" => ["arg1", "arg2"],
         "jobs" => [
           {
-            "name"=>"FetchFirstJob",
+            "name"=>an_instance_of(String),
             "klass"=>"FetchFirstJob",
             "incoming"=>[],
             "outgoing"=>["PersistFirstJob"],
@@ -94,7 +95,7 @@ describe Gush::Workflow do
             "output_payload" => nil
           },
           {
-            "name"=>"PersistFirstJob",
+            "name"=>an_instance_of(String),
             "klass"=>"PersistFirstJob",
             "incoming"=>["FetchFirstJob"],
             "outgoing"=>[],
@@ -107,7 +108,7 @@ describe Gush::Workflow do
           }
         ]
       }
-      expect(result).to match(expected)
+      expect(result).to match(a_hash_including(expected))
     end
   end
 
@@ -145,7 +146,7 @@ describe Gush::Workflow do
 
       tree.resolve_dependencies
 
-      expect(tree.jobs.first.outgoing).to match_array([klass2.to_s])
+      expect(tree.jobs.first.outgoing).to match_array(jobs_with_id([klass2.to_s]))
     end
 
     it "allows `before` to accept an array of jobs" do
@@ -159,7 +160,7 @@ describe Gush::Workflow do
 
       tree.resolve_dependencies
 
-      expect(tree.jobs.first.incoming).to match_array([klass2.to_s])
+      expect(tree.jobs.first.incoming).to match_array(jobs_with_id([klass2.to_s]))
     end
 
     it "attaches job as a child of the job in `after` key" do
@@ -170,7 +171,7 @@ describe Gush::Workflow do
       tree.run(klass2, after: klass1)
       tree.resolve_dependencies
       job = tree.jobs.first
-      expect(job.outgoing).to match_array([klass2.to_s])
+      expect(job.outgoing).to match_array(jobs_with_id([klass2.to_s]))
     end
 
     it "attaches job as a parent of the job in `before` key" do
@@ -181,7 +182,7 @@ describe Gush::Workflow do
       tree.run(klass2, before: klass1)
       tree.resolve_dependencies
       job = tree.jobs.first
-      expect(job.incoming).to match_array([klass2.to_s])
+      expect(job.incoming).to match_array(jobs_with_id([klass2.to_s]))
     end
   end
 

--- a/spec/lib/gush/workflow_spec.rb
+++ b/spec/lib/gush/workflow_spec.rb
@@ -80,7 +80,6 @@ describe Gush::Workflow do
           "finished_at" => nil,
           "stopped" => false,
           "arguments" => ["arg1", "arg2"],
-          "nameize_payloads" => false,
           "jobs" => [
               {
                   "name"=>a_string_starting_with('FetchFirstJob'),

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'gush'
 require 'pry'
 require 'sidekiq/testing'
-require 'rspec/json_expectations'
 
 Sidekiq::Testing.fake!
 Sidekiq::Logging.logger = nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'gush'
 require 'pry'
 require 'sidekiq/testing'
+require 'rspec/json_expectations'
 
 Sidekiq::Testing.fake!
 Sidekiq::Logging.logger = nil
@@ -11,6 +12,7 @@ class FetchSecondJob < Gush::Job; end
 class PersistFirstJob < Gush::Job; end
 class PersistSecondJob < Gush::Job; end
 class NormalizeJob < Gush::Job; end
+class BobJob < Gush::Job; end
 
 GUSHFILE  = Pathname.new(__FILE__).parent.join("Gushfile.rb")
 
@@ -38,6 +40,14 @@ REDIS_URL = "redis://localhost:6379/12"
 module GushHelpers
   def redis
     @redis ||= Redis.new(url: REDIS_URL)
+  end
+
+  def jobs_with_id(jobs_array)
+    jobs_array.map {|job_name| job_with_id(job_name) }
+  end
+
+  def job_with_id(job_name)
+    /#{job_name}-(?<identifier>.*)/
   end
 end
 


### PR DESCRIPTION
Hey, like we've discussed in https://github.com/chaps-io/gush/issues/21, I need to have unique names for jobs that run the same class with different params. 

Here is my solution to the problem - I've also updated rspec tests for it (all green now), as well as added mine that is using the new `nameize_payloads!` method. What it does is changing the way payloads are delivered - they can be either delivered as an array of strings or hashes, depending on how detailed your payloads needs to be:

```ruby
#normal approach
payloads['DummyJob'] => ['one','two','three']

#hashes approach
payloads['DummyJob'] => [{:id => 'DummyJob-1',:payload => 'one'}]
```

Hope that you can merge this, so everyone can use it. 
