### PR TITLE
Add a Sidekiq logger to jobs

### DIFF
--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -98,6 +98,10 @@ module Gush
     end
 
     private
+    def logger
+      Sidekiq.logger
+    end
+
     def current_timestamp
       Time.now.to_i
     end


### PR DESCRIPTION
As discussed in https://github.com/chaps-io/gush/issues/17.
I've added the code you've provided to the `Gush::Job` class - tested in on my working development, everything is logging smooth.