### PR TITLE
Updated to MultiJson (JSON engine interface)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
+platforms :mri, :ruby do
+  gem 'yajl-ruby'
+end
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
-
-# Specify your gem's dependencies in gush.gemspec
 gemspec
 
-gem 'pry'
-gem 'yajl-ruby'
-gem "fakeredis", require: false

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "sidekiq", "~> 4.0"
-  spec.add_dependency "yajl-ruby", "~> 1.2"
+  spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", "~> 3.2"
   spec.add_dependency "hiredis", "~> 0.6"
   spec.add_dependency "ruby-graphviz", "~> 1.2"
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rspec", '~> 3.0'
+  spec.add_development_dependency "pry", '~> 0.10'
+  spec.add_development_dependency 'fakeredis', '~> 0.5'
 end

--- a/lib/gush.rb
+++ b/lib/gush.rb
@@ -6,6 +6,7 @@ require "pathname"
 require "redis"
 require "securerandom"
 require "sidekiq"
+require "multi_json"
 
 require "gush/json"
 require "gush/cli"

--- a/lib/gush/configuration.rb
+++ b/lib/gush/configuration.rb
@@ -1,5 +1,3 @@
-require 'yajl'
-
 module Gush
   class Configuration
     attr_accessor :concurrency, :namespace, :redis_url, :environment

--- a/lib/gush/json.rb
+++ b/lib/gush/json.rb
@@ -1,7 +1,7 @@
 module Gush
   class JSON
-    def self.encode(data, options = {})
-      MultiJson.dump(data, options)
+    def self.encode(data)
+      MultiJson.dump(data)
     end
 
     def self.decode(data, options = {})

--- a/lib/gush/json.rb
+++ b/lib/gush/json.rb
@@ -1,11 +1,11 @@
 module Gush
   class JSON
-    def self.encode(data)
-      Yajl::Encoder.new.encode(data)
+    def self.encode(data, options = {})
+      MultiJson.dump(data, options)
     end
 
     def self.decode(data, options = {})
-      Yajl::Parser.parse(data, options)
+      MultiJson.load(data, options)
     end
   end
 end

--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -1,5 +1,4 @@
 require 'sidekiq'
-require 'yajl'
 
 module Gush
   class Worker

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'gush'
-require 'pry'
+require 'fakeredis'
 require 'sidekiq/testing'
 
 Sidekiq::Testing.fake!


### PR DESCRIPTION
Gush is incompatible with JRuby, as yajl-ruby is a Ruby wrapper for the C yajl library. MultiJson is an interface which will call an underlying library to parse the JSON. 

This pull request keeps yajl-ruby for Ruby platforms, and MultiJson should use continue to use it if the user has not specified a different engine. 

Bundler will not fail on attempting to install the native C extensions. 