### PR TITLE
Downgrade ActiveJob dependency to 4.2

### DIFF
--- a/gush.gemspec
+++ b/gush.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activejob", "~> 5.0"
+  spec.add_dependency "activejob", ">= 4.2.7", "< 6.0"
   spec.add_dependency "connection_pool", "~> 2.2.1"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 5"


### PR DESCRIPTION
Hi, thank you for your work with Gush. We're considering using it for a Rails 4.2 project but the `gemspec` currently has a `~> 5.0` dependency. However, we don't think that there are any meaningful differences for `gush` — all tests pass with 4.2. 

Is there anything else that we should be checking? If not, what do you think about merging this? I imagine there are still a good number of Rails 4 projects out there. 

Thank you!