### PR TITLE
Add Gush::Job#skip!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Add `Gush::Job#skip!` that marks a job as `#skipped?` and skips the remaining code. [See pull request](https://github.com/chaps-io/gush/pull/66).
+
 ## 2.0.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -323,6 +323,25 @@ it will generate a workflow with 5 `NotificationJob`s and one `AdminNotification
 
 ![DynamicWorkflow](https://i.imgur.com/HOI3fjc.png)
 
+### Skipping a Job
+
+Sometimes you'd like to skip a job, which doesn't mean that job/workflow has failed. You can call `self.skip!` inside the job to mark it as a `skipped`:
+
+```ruby
+class ProcessUserJob < Gush::Job
+  def perform
+    user = User.find params[:id]
+
+    self.skip! if user.processed?
+
+    # Code beneath here will not be called anymore
+    # and the job will be marked as 'skipped'
+    # 
+    # The workflow will continue on normally to the other jobs
+  end
+end
+```
+
 ## Command line interface (CLI)
 
 ### Checking status
@@ -350,7 +369,7 @@ bundle exec gush viz <NameOfTheWorkflow>
 
 ### Cleaning up afterwards
 
-Running `NotifyWorkflow.create` inserts multiple keys into Redis every time it is ran.  This data might be useful for analysis but at a certain point it can be purged via Redis TTL.  By default gush and Redis will keep keys forever.  To configure expiration you need to 2 things.  Create initializer (specify config.ttl in seconds, be different per environment).  
+Running `NotifyWorkflow.create` inserts multiple keys into Redis every time it is ran.  This data might be useful for analysis but at a certain point it can be purged via Redis TTL.  By default gush and Redis will keep keys forever.  To configure expiration you need to 2 things.  Create initializer (specify config.ttl in seconds, be different per environment).
 
 ```ruby
 # config/initializers/gush.rb
@@ -361,7 +380,7 @@ Gush.configure do |config|
 end
 ```
 
-And you need to call `flow.expire!` (optionally passing custom TTL value overriding `config.ttl`).  This gives you control whether to expire data for specific workflow.  Best NOT to set TTL to be too short (like minutes) but about a week in length.  And you can run `Client.expire_workflow` and `Client.expire_job` passing appropriate IDs and TTL (pass -1 to NOT expire) values.  
+And you need to call `flow.expire!` (optionally passing custom TTL value overriding `config.ttl`).  This gives you control whether to expire data for specific workflow.  Best NOT to set TTL to be too short (like minutes) but about a week in length.  And you can run `Client.expire_workflow` and `Client.expire_job` passing appropriate IDs and TTL (pass -1 to NOT expire) values.
 
 ### Avoid overlapping workflows
 

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -67,6 +67,11 @@ module Gush
       @finished_at = @failed_at = current_timestamp
     end
 
+    def skip!
+      @finished_at = @skipped_at = current_timestamp
+      throw(:skipped_job)
+    end
+
     def enqueued?
       !enqueued_at.nil?
     end

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -1,7 +1,8 @@
 module Gush
   class Job
     attr_accessor :workflow_id, :incoming, :outgoing, :params,
-      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads, :klass, :queue
+      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads, :klass,
+      :queue, :skipped_at
     attr_reader :id, :klass, :output_payload, :params
 
     def initialize(opts = {})
@@ -19,6 +20,7 @@ module Gush
         finished_at: finished_at,
         enqueued_at: enqueued_at,
         started_at: started_at,
+        skipped_at: skipped_at,
         failed_at: failed_at,
         params: params,
         workflow_id: workflow_id,
@@ -71,6 +73,10 @@ module Gush
 
     def finished?
       !finished_at.nil?
+    end
+
+    def skipped?
+      !skipped_at.nil?
     end
 
     def failed?
@@ -126,6 +132,7 @@ module Gush
       @output_payload = opts[:output_payload]
       @workflow_id    = opts[:workflow_id]
       @queue          = opts[:queue]
+      @skipped_at     = opts[:skipped_at]
     end
   end
 end

--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -12,7 +12,9 @@ module Gush
 
       mark_as_started
       begin
-        job.perform
+        catch(:skipped_job) do
+          job.perform
+        end
       rescue StandardError => error
         mark_as_failed
         raise error

--- a/spec/gush/job_spec.rb
+++ b/spec/gush/job_spec.rb
@@ -9,12 +9,25 @@ describe Gush::Job do
       expect(job.output_payload).to eq("something")
     end
   end
+
   describe "#fail!" do
     it "sets finished and failed to true and records time" do
       job = described_class.new(name: "a-job")
       job.fail!
       expect(job.failed_at).to eq(Time.now.to_i)
       expect(job.failed?).to eq(true)
+      expect(job.finished?).to eq(true)
+      expect(job.running?).to eq(false)
+      expect(job.enqueued?).to eq(false)
+    end
+  end
+
+  describe "#skip!" do
+    it "sets finished and skipped to true and records time" do
+      job = described_class.new(name: "a-job")
+      expect { job.skip! }.to throw_symbol(:skipped_job)
+      expect(job.skipped_at).to eq(Time.now.to_i)
+      expect(job.skipped?).to eq(true)
       expect(job.finished?).to eq(true)
       expect(job.running?).to eq(false)
       expect(job.enqueued?).to eq(false)

--- a/spec/gush/job_spec.rb
+++ b/spec/gush/job_spec.rb
@@ -78,6 +78,7 @@ describe Gush::Job do
           outgoing: [],
           failed_at: nil,
           started_at: nil,
+          skipped_at: nil,
           finished_at: 123,
           enqueued_at: 120,
           params: {},


### PR DESCRIPTION
As per discussion in #65 this pull request adds a `Gush::Job#skip!` that would mark a job as skipped, and returns from the point where `self.skip!` is called. After calling `self.skip!`, the workflow continues on with the other jobs.

Note: @pokonski was thinking of adding `.skip_remaining!` on another PR to keep the PR's small. What do you think? Or should I include that suggestion in this PR too?