### PR TITLE
Try to enqueue outgoing jobs in another worker

### DIFF
--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -82,7 +82,7 @@ module Gush
         end
       end
     rescue RedisMutex::LockError
-      Worker.perform_later(*[workflow_id, job.name])
+      Worker.set(wait: 2.seconds).perform_later(workflow_id, job.name)
     end
   end
 end

--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -6,6 +6,12 @@ module Gush
     def perform(workflow_id, job_id)
       setup_job(workflow_id, job_id)
 
+      if job.succeeded?
+        # Try to enqueue outgoing jobs again because the last job has redis mutex lock error
+        enqueue_outgoing_jobs
+        return
+      end
+
       job.payloads = incoming_payloads
 
       error = nil
@@ -75,6 +81,8 @@ module Gush
           end
         end
       end
+    rescue RedisMutex::LockError
+      Worker.perform_later(*[workflow_id, job.name])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,6 +78,19 @@ RSpec::Matchers.define :have_jobs do |flow, jobs|
   end
 end
 
+RSpec::Matchers.define :have_no_jobs do |flow, jobs|
+  match do |actual|
+    expected = jobs.map do |job|
+      hash_including(args: include(flow, job))
+    end
+    expect(ActiveJob::Base.queue_adapter.enqueued_jobs).not_to match_array(expected)
+  end
+
+  failure_message do |actual|
+    "expected queue to have no #{jobs}, but instead has: #{ActiveJob::Base.queue_adapter.enqueued_jobs.map{ |j| j[:args][1]}}"
+  end
+end
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include GushHelpers


### PR DESCRIPTION
# Summary

This commit is trying to fix issue RedisMutex::LockError on
https://github.com/chaps-io/gush/issues/57.
Whenever we have the error, it simply enqueues another worker.
At the begin of the worker, if the job is succedeed, we simply call
`enqueue_outgoing_jobs` again.