### PR TITLE
Fix CLI to display removed/renamed jobs

### DIFF
--- a/lib/gush.rb
+++ b/lib/gush.rb
@@ -15,6 +15,7 @@ require "gush/client"
 require "gush/configuration"
 require "gush/errors"
 require "gush/job"
+require "gush/nil_job"
 require "gush/worker"
 require "gush/workflow"
 

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -36,6 +36,8 @@ module Gush
 
     def self.from_hash(hash)
       hash[:klass].constantize.new(hash)
+    rescue NameError
+      Gush::NilJob.new(hash)
     end
 
     def output(data)

--- a/lib/gush/nil_job.rb
+++ b/lib/gush/nil_job.rb
@@ -1,0 +1,7 @@
+module Gush
+  class NilJob < Job
+    def name
+      @name ||= "Removed - #{klass}|#{id}"
+    end
+  end
+end

--- a/spec/gush/job_spec.rb
+++ b/spec/gush/job_spec.rb
@@ -91,33 +91,66 @@ describe Gush::Job do
   end
 
   describe ".from_hash" do
-    it "properly restores state of the job from hash" do
-      job = described_class.from_hash(
-        {
-          klass: 'Gush::Job',
-          id: '702bced5-bb72-4bba-8f6f-15a3afa358bd',
-          incoming: ['a', 'b'],
-          outgoing: ['c'],
-          failed_at: 123,
-          finished_at: 122,
-          started_at: 55,
-          enqueued_at: 444
-        }
-      )
+    context 'when the job is existed' do
+      it "properly restores state of the job from hash" do
+        job = described_class.from_hash(
+          {
+            klass: 'Gush::Job',
+            id: '702bced5-bb72-4bba-8f6f-15a3afa358bd',
+            incoming: ['a', 'b'],
+            outgoing: ['c'],
+            failed_at: 123,
+            finished_at: 122,
+            started_at: 55,
+            enqueued_at: 444
+          }
+        )
 
-      expect(job.id).to eq('702bced5-bb72-4bba-8f6f-15a3afa358bd')
-      expect(job.name).to eq('Gush::Job|702bced5-bb72-4bba-8f6f-15a3afa358bd')
-      expect(job.class).to eq(Gush::Job)
-      expect(job.klass).to eq("Gush::Job")
-      expect(job.finished?).to eq(true)
-      expect(job.failed?).to eq(true)
-      expect(job.enqueued?).to eq(true)
-      expect(job.incoming).to eq(['a', 'b'])
-      expect(job.outgoing).to eq(['c'])
-      expect(job.failed_at).to eq(123)
-      expect(job.finished_at).to eq(122)
-      expect(job.started_at).to eq(55)
-      expect(job.enqueued_at).to eq(444)
+        expect(job.id).to eq('702bced5-bb72-4bba-8f6f-15a3afa358bd')
+        expect(job.name).to eq('Gush::Job|702bced5-bb72-4bba-8f6f-15a3afa358bd')
+        expect(job.class).to eq(Gush::Job)
+        expect(job.klass).to eq("Gush::Job")
+        expect(job.finished?).to eq(true)
+        expect(job.failed?).to eq(true)
+        expect(job.enqueued?).to eq(true)
+        expect(job.incoming).to eq(['a', 'b'])
+        expect(job.outgoing).to eq(['c'])
+        expect(job.failed_at).to eq(123)
+        expect(job.finished_at).to eq(122)
+        expect(job.started_at).to eq(55)
+        expect(job.enqueued_at).to eq(444)
+      end
+    end
+
+    context 'when the job is removed' do
+      it "properly restores state of the job from hash" do
+        job = described_class.from_hash(
+          {
+            klass: 'Gush::RemovedJob',
+            id: '702bced5-bb72-4bba-8f6f-15a3afa358bd',
+            incoming: ['a', 'b'],
+            outgoing: ['c'],
+            failed_at: 123,
+            finished_at: 122,
+            started_at: 55,
+            enqueued_at: 444
+          }
+        )
+
+        expect(job.id).to eq('702bced5-bb72-4bba-8f6f-15a3afa358bd')
+        expect(job.name).to eq('Removed - Gush::RemovedJob|702bced5-bb72-4bba-8f6f-15a3afa358bd')
+        expect(job.class).to eq(Gush::NilJob)
+        expect(job.klass).to eq("Gush::RemovedJob")
+        expect(job.finished?).to eq(true)
+        expect(job.failed?).to eq(true)
+        expect(job.enqueued?).to eq(true)
+        expect(job.incoming).to eq(['a', 'b'])
+        expect(job.outgoing).to eq(['c'])
+        expect(job.failed_at).to eq(123)
+        expect(job.finished_at).to eq(122)
+        expect(job.started_at).to eq(55)
+        expect(job.enqueued_at).to eq(444)
+      end
     end
   end
 end

--- a/spec/gush/nil_job_spec.rb
+++ b/spec/gush/nil_job_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Gush::NilJob do
+  describe '#name' do
+    it 'prepends "Removed - "' do
+      job = described_class.from_hash(
+        klass: 'Gush::RemovedJob',
+        id: '702bced5-bb72-4bba-8f6f-15a3afa358bd'
+      )
+
+      expect(job.name).to eq('Removed - Gush::RemovedJob|702bced5-bb72-4bba-8f6f-15a3afa358bd')
+    end
+  end
+end


### PR DESCRIPTION
# Summary

When we remove the job `Jobs::SayHello`, but the job is still
persisted on Redis. The CLI `list/show` will raise an error. This PR is to fix
this error which allows the CLI to display removed/renamed jobs.

## Before

```
❯ ./bin/gush show <workflow-id>
/Users/employmenthero/.asdf/installs/ruby/2.4.6/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/inflector/methods.rb:285:in `const_get': uninitialized constant
Jobs::SayHello (NameError)
```

## After

```
[✓] Removed - Jobs::SayHello|059349f6-5629-4f93-83bb-db52659b9b75
[✓] Removed - Jobs::SayHello|6343f0ab-a295-4a5b-b48c-96660e5691c2
[✓] Removed - Jobs::SayHello|6874b417-ee47-4701-8b5e-d076624b05ad
[✓] Removed - Jobs::SayHello|fddd49bd-984a-4c7c-b31c-74676fd65877
[✓] Removed - Jobs::SayHello|fa59fc43-da22-483b-84f5-f7f1c34bf7e8
[✓] Removed - Jobs::SayHello|df8dc75d-4513-4687-a520-e2a572ba2a01
[✓] Removed - Jobs::SayHello|82cc8060-d31b-471d-9a12-6e6e092f23e3
[✓] Removed - Jobs::SayHello|12f495c3-0f8d-458e-af32-c392b6a9b3ef
[✓] Removed - Jobs::SayHello|fba46058-d133-424d-8514-d4bfe02486f0
[✓] Removed - Jobs::SayHello|c9ebae45-077f-4548-944f-49d17c88637c
```