### PR TITLE
Limit number of redis connections and fix ttl bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ tmp
 test.rb
 /Gushfile
 dump.rdb
+.ruby-version
+.ruby-gemset

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.2.2
   - 2.3.4
   - 2.4.1
+  - 2.5
+  - 2.6
+  - 2.7
 services:
   - redis-server
 email:

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activejob", ">= 4.2.7", "< 6.0"
-  spec.add_dependency "connection_pool", "~> 2.2.1"
+  spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 5"
   spec.add_dependency "redis-mutex", "~> 4.0.1"
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "colorize", "~> 0.7"
   spec.add_dependency "thor", "~> 0.19"
   spec.add_dependency "launchy", "~> 2.4"
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rspec", '~> 3.0'
   spec.add_development_dependency "pry", '~> 0.10'

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -149,7 +149,7 @@ module Gush
 
     def expire_job(workflow_id, job, ttl=nil)
       ttl = ttl || configuration.ttl
-      redis.expire("gush.jobs.#{workflow_id}.#{job.name}", ttl)
+      redis.expire("gush.jobs.#{workflow_id}.#{job.klass}", ttl)
     end
 
     def enqueue_job(workflow_id, job)

--- a/spec/gush/client_spec.rb
+++ b/spec/gush/client_spec.rb
@@ -95,12 +95,18 @@ describe Gush::Client do
   end
 
   describe "#expire_workflow" do
+    let(:ttl) { 2000 }
+
     it "sets TTL for all Redis keys related to the workflow" do
       workflow = TestWorkflow.create
 
-      client.expire_workflow(workflow, -1)
+      client.expire_workflow(workflow, ttl)
 
-      # => TODO - I believe fakeredis does not handle TTL the same.   
+      expect(redis.ttl("gush.workflows.#{workflow.id}")).to eq(ttl)
+
+      workflow.jobs.each do |job|
+        expect(redis.ttl("gush.jobs.#{workflow.id}.#{job.klass}")).to eq(ttl)
+      end
     end
   end
 


### PR DESCRIPTION
- Previously (before commit a94719b) each gush object that had a method `client` with a memoized `Client.new` would create a new redis connection. This was causing a lot of redis connections for us & causing us to hit the limit of our redis instance. With commit a94719b, we now hold only open redis connection per thread via a thread local class variable. This lowers the amount of redis connection substantially.
- Commit 1c12ce2 fixes a bug where TTL was not being set correct for job key causing job keys to never be expired.