### PR TITLE
Gush can work with ActiveJob 6, no need to limit it to < 6.0.

### DIFF
--- a/gush.gemspec
+++ b/gush.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activejob", ">= 4.2.7", "< 6.0"
+  spec.add_dependency "activejob", ">= 4.2.7", "< 7.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 5"


### PR DESCRIPTION
We are using Gush with Rails/ActiveJob 6 in our application & we are not thus far seeing any issue.