### PR TITLE
Remove load bundler at bin file

### DIFF
--- a/bin/gush
+++ b/bin/gush
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 require "pathname"
-require "bundler"
-Bundler.require
 
 bin_file = Pathname.new(__FILE__).realpath
 # add self to libpath


### PR DESCRIPTION
The following error occurred and has been fixed.

```
$ bundle exec gush list
bundler: failed to load command: gush (/Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bin/gush)
NameError: uninitialized constant ActiveStorageValidations::ActiveModel
Did you mean?  ActiveJob
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/active_storage_validations-0.7.1/lib/active_storage_validations/attached_validator.rb:4:in `<module:ActiveStorageValidations>'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/active_storage_validations-0.7.1/lib/active_storage_validations/attached_validator.rb:3:in `<top (required)>'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/active_storage_validations-0.7.1/lib/active_storage_validations.rb:5:in `require'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/active_storage_validations-0.7.1/lib/active_storage_validations.rb:5:in `<top (required)>'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `require'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `block (2 levels) in require'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `each'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `block in require'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `each'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `require'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler.rb:174:in `require'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/gush-2.0.1/bin/gush:4:in `<top (required)>'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bin/gush:23:in `load'
  /Users/mat_aki/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bin/gush:23:in `<top (required)>'
```

The error occurred when using a gem that loads ActiveRecord or ActiveModel together.