### PR TITLE
Use Redis#exists? in Gush::Client.next_free_workflow_id

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,5 @@
+exit
+n
+step
+n
+redis.respond_to?(:exists?)

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test.rb
 dump.rdb
 .ruby-version
 .ruby-gemset
+*.sw*

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rspec", '~> 3.0'
   spec.add_development_dependency "pry", '~> 0.10'
-  spec.add_development_dependency 'fakeredis', '~> 0.5'
 end

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -72,7 +72,11 @@ module Gush
       id = nil
       loop do
         id = SecureRandom.uuid
-        available = !redis.exists("gush.workflow.#{id}")
+        available = if redis.respond_to?(:exists?)
+                      !redis.exists?("gush.workflow.#{id}")
+                    else
+                      !redis.exists("gush.workflow.#{id}")
+                    end
 
         break if available
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'gush'
-require 'fakeredis'
 require 'json'
 require 'pry'
 


### PR DESCRIPTION
Noticed this warning popping up after upgrading the [`redis`](https://github.com/redis/redis-rb) Gem from `3.3.5` to `4.2.2`.

```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0.
```

This change suppresses the warning and better prepares `gush` for `redis` `5.0`.