### PR TITLE
Fix broken ci

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ require 'pry'
 ActiveJob::Base.queue_adapter = :test
 ActiveJob::Base.logger = nil
 
+# NOTE: This is a workaround for avoiding spec failures until the commit will be released: https://github.com/guilleiguaran/fakeredis/commit/f68bd4f8d2b87c6445b9166447c1752c6236d63b
+Redis.exists_returns_integer = true
+
 class Prepare < Gush::Job; end
 class FetchFirstJob < Gush::Job; end
 class FetchSecondJob < Gush::Job; end


### PR DESCRIPTION
Since redis-rb 4.2.0, the internal implementation of `exists` has changed, causing the test to fail.

Although redis-rb expects the internal implementation to return Integer as a response to the `exists` command, but the internal implementation in testing (= fakeredis) returns Boolean for `exists,` causing the error. The fix for this on fakeredis has commited but not released yet.

To avoid the error, we set a redis-rb feature flag.