### PR TITLE
Add Rails version to CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        rails_version: [4.2.7, 5.1.0, 5.2.0, 6.0.0, 6.1.0]
         ruby-version: ['2.6', '2.7', '3.0']
 
     steps:
@@ -36,6 +37,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      env:
+        RAILS_VERSION: "${{ matrix.rails_version }}"
     - name: Install Graphviz
       run: sudo apt-get install graphviz
     - name: Run tests

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source 'https://rubygems.org'
 gemspec
 
+rails_version = ENV['RAILS_VERSION'] || '< 7.0'
+rails_version = "~> #{rails_version}" if rails_version =~ /^\d/
+gem 'activejob', rails_version
+
 platforms :mri, :ruby do
   gem 'yajl-ruby'
 end


### PR DESCRIPTION
Add Rails version to CI matrix. The versions of rails in matrix, the supported major versions by gush currently.