### PR TITLE
Add wait parameter to jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,23 @@ class NotifyWorkflow < Gush::Workflow
 end
 ```
 
+### Dynamic waitable time for jobs
+
+There might be a case you want to configure a job to be executed after a time. Based on above example, we want to configure `AdminNotificationJob` to be executed after 5 seconds.
+
+```ruby
+
+class NotifyWorkflow < Gush::Workflow
+  def configure(user_ids)
+    notification_jobs = user_ids.map do |user_id|
+      run NotificationJob, params: {user_id: user_id}, queue: 'user'
+    end
+
+    run AdminNotificationJob, after: notification_jobs, queue: 'admin', wait: 5.seconds
+  end
+end
+```
+
 ## Command line interface (CLI)
 
 ### Checking status

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -156,8 +156,13 @@ module Gush
       job.enqueue!
       persist_job(workflow_id, job)
       queue = job.queue || configuration.namespace
-
-      Gush::Worker.set(queue: queue).perform_later(*[workflow_id, job.name])
+      wait = job.wait
+      
+      if wait.present?
+        Gush::Worker.set(queue: queue, wait: wait).perform_later(*[workflow_id, job.name])
+      else
+        Gush::Worker.set(queue: queue).perform_later(*[workflow_id, job.name])
+      end
     end
 
     private

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -1,7 +1,8 @@
 module Gush
   class Job
     attr_accessor :workflow_id, :incoming, :outgoing, :params,
-      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads, :klass, :queue
+      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads, 
+      :klass, :queue, :wait 
     attr_reader :id, :klass, :output_payload, :params
 
     def initialize(opts = {})
@@ -126,6 +127,7 @@ module Gush
       @output_payload = opts[:output_payload]
       @workflow_id    = opts[:workflow_id]
       @queue          = opts[:queue]
+      @wait           = opts[:wait]
     end
   end
 end

--- a/lib/gush/workflow.rb
+++ b/lib/gush/workflow.rb
@@ -112,7 +112,8 @@ module Gush
         workflow_id: id,
         id: client.next_free_job_id(id, klass.to_s),
         params: opts.fetch(:params, {}),
-        queue: opts[:queue]
+        queue: opts[:queue],
+        wait: opts[:wait]
       })
 
       jobs << node

--- a/spec/gush/client_spec.rb
+++ b/spec/gush/client_spec.rb
@@ -37,6 +37,18 @@ describe Gush::Client do
   end
 
   describe "#start_workflow" do
+    context "when there is wait parameter configured" do
+      let(:freeze_time) { Time.utc(2023, 01, 21, 14, 36, 0) }
+
+      it "schedules job execution" do
+        travel_to freeze_time do
+          workflow = WaitableTestWorkflow.create
+          client.start_workflow(workflow)
+          expect(Gush::Worker).to have_a_job_enqueued_at(workflow.id, job_with_id("Prepare"), 5.minutes)
+        end
+      end
+    end
+
     it "enqueues next jobs from the workflow" do
       workflow = TestWorkflow.create
       expect {

--- a/spec/gush/workflow_spec.rb
+++ b/spec/gush/workflow_spec.rb
@@ -121,6 +121,13 @@ describe Gush::Workflow do
       expect(flow.jobs.first.params).to eq ({ something: 1 })
     end
 
+    it "allows passing wait param to the job" do
+      flow = Gush::Workflow.new
+      flow.run(Gush::Job, wait: 5.seconds)
+      flow.save
+      expect(flow.jobs.first.wait).to eq (5.seconds)
+    end
+
     context "when graph is empty" do
       it "adds new job with the given class as a node" do
         flow = Gush::Workflow.new


### PR DESCRIPTION
This PR adds `wait` as a paremeter to `run` method on `Gush::Workflow`.