### PR TITLE
Update redis dependency  >= 3.2, < 6

### DIFF
--- a/gush.gemspec
+++ b/gush.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activejob", ">= 4.2.7", "< 7.1"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
-  spec.add_dependency "redis", ">= 3.2", "< 5"
+  spec.add_dependency "redis", ">= 3.2", "~> 5"
   spec.add_dependency "redis-mutex", "~> 4.0.1"
   spec.add_dependency "hiredis", "~> 0.6"
   spec.add_dependency "graphviz", "~> 1.2"

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activejob", ">= 4.2.7", "< 7.1"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
-  spec.add_dependency "redis", ">= 3.2", "~> 5"
+  spec.add_dependency "redis", ">= 3.2", "< 6"
   spec.add_dependency "redis-mutex", "~> 4.0.1"
   spec.add_dependency "hiredis", "~> 0.6"
   spec.add_dependency "graphviz", "~> 1.2"

--- a/spec/gush/client_spec.rb
+++ b/spec/gush/client_spec.rb
@@ -125,7 +125,7 @@ describe Gush::Client do
   describe "#persist_job" do
     it "persists JSON dump of the job in Redis" do
 
-      job = BobJob.new(name: 'bob')
+      job = BobJob.new(name: 'bob', id: 'abcd123')
 
       client.persist_job('deadbeef', job)
       expect(redis.keys("gush.jobs.deadbeef.*").length).to eq(1)


### PR DESCRIPTION
Updating gemspec to allow redis v5.
Fix a test that did not have an id, redis v5 will error on an attempt to set a nil key in a hash.