### PR TITLE
Allow configuring redis via a option hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,17 @@ def find_by_class klass
 end
 ```
 
+## Running Gush on Heroku with Redis 6+
+
+Redis 6+ requires SSL to connect. Heroku does not use SSL, they use HTTP routing instead. You can setup Redis with these options to run on Heroku with Redis 6+:
+
+```ruby
+# config/initializers/gush.rb
+Gush.configure do |config|
+  config.redis = { url: "redis://localhost:6379", ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }}
+end
+```
+
 ## Contributors
 
 - [Mateusz Lenik](https://github.com/mlen)

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -8,12 +8,14 @@ module Gush
     @@redis_connection = Concurrent::ThreadLocalVar.new(nil)
 
     def self.redis_connection(config)
-      cached = (@@redis_connection.value ||= { url: config.redis_url, connection: nil })
-      return cached[:connection] if !cached[:connection].nil? && config.redis_url == cached[:url]
+      redis_options = config.redis ? config.redis : { url: config.redis_url }
 
-      Redis.new(url: config.redis_url).tap do |instance|
+      cached = (@@redis_connection.value ||= { url: redis_options[:url], connection: nil })
+      return cached[:connection] if !cached[:connection].nil? && redis_options[:url] == cached[:url]
+
+      Redis.new(redis_options).tap do |instance|
         RedisClassy.redis = instance
-        @@redis_connection.value = { url: config.redis_url, connection: instance }
+        @@redis_connection.value = { url: redis_options[:url], connection: instance }
       end
     end
 

--- a/lib/gush/configuration.rb
+++ b/lib/gush/configuration.rb
@@ -1,6 +1,6 @@
 module Gush
   class Configuration
-    attr_accessor :concurrency, :namespace, :redis_url, :ttl, :locking_duration, :polling_interval
+    attr_accessor :concurrency, :namespace, :redis_url, :redis, :ttl, :locking_duration, :polling_interval
 
     def self.from_json(json)
       new(Gush::JSON.decode(json, symbolize_keys: true))
@@ -10,6 +10,7 @@ module Gush
       self.concurrency      = hash.fetch(:concurrency, 5)
       self.namespace        = hash.fetch(:namespace, 'gush')
       self.redis_url        = hash.fetch(:redis_url, 'redis://localhost:6379')
+      self.redis            = hash.fetch(:redis, nil)
       self.gushfile         = hash.fetch(:gushfile, 'Gushfile')
       self.ttl              = hash.fetch(:ttl, -1)
       self.locking_duration = hash.fetch(:locking_duration, 2) # how long you want to wait for the lock to be released, in seconds
@@ -29,6 +30,7 @@ module Gush
         concurrency:      concurrency,
         namespace:        namespace,
         redis_url:        redis_url,
+        redis:            redis,
         ttl:              ttl,
         locking_duration: locking_duration,
         polling_interval: polling_interval

--- a/spec/gush/configuration_spec.rb
+++ b/spec/gush/configuration_spec.rb
@@ -16,12 +16,14 @@ describe Gush::Configuration do
     it "allows setting options through a block" do
       Gush.configure do |config|
         config.redis_url = "redis://localhost"
+        config.redis = { url: "redis://localhost" }
         config.concurrency = 25
         config.locking_duration = 5
         config.polling_interval = 0.5
       end
 
       expect(Gush.configuration.redis_url).to eq("redis://localhost")
+      expect(Gush.configuration.redis).to eq({ url: "redis://localhost" })
       expect(Gush.configuration.concurrency).to eq(25)
       expect(Gush.configuration.locking_duration).to eq(5)
       expect(Gush.configuration.polling_interval).to eq(0.5)


### PR DESCRIPTION
Redis 6+ requires SSL to connect. Heroku does not use SSL, they use HTTP routing instead.

This PR allows to configure Redis via an option hash like:

```ruby
# config/initializers/gush.rb
Gush.configure do |config|
  config.redis = { url: "redis://localhost:6379", ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }}
end
```