### PR TITLE
Feat/rails 7.1.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,14 +20,14 @@ jobs:
     services:
       redis:
         image: redis:alpine
-        ports: ["6379:6379"]
+        ports: [ "6379:6379" ]
         options: --entrypoint redis-server
 
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails_version: ['4.2.7', '5.1.0', '5.2.0', '6.0.0', '6.1.0', '7.0']
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        rails_version: [ '4.2.7', '5.1.0', '5.2.0', '6.0.0', '6.1.0', '7.0', '7.1', '7.1.2' ]
+        ruby-version: [ '2.6', '2.7', '3.0', '3.1' ]
         exclude:
           - ruby-version: '3.0'
             rails_version: '4.2.7'
@@ -53,19 +53,23 @@ jobs:
             rails_version: '6.1'
           - ruby-version: '2.6'
             rails_version: '7.0'
+          - ruby-version: '2.6'
+            rails_version: '7.1'
+          - ruby-version: '2.6'
+            rails_version: '7.1.2'
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      env:
-        RAILS_VERSION: "${{ matrix.rails_version }}"
-    - name: Install Graphviz
-      run: sudo apt-get install graphviz
-    - name: Run tests
-      run: bundle exec rspec
-      env:
-        REDIS_URL: redis://localhost:6379/1
-        RAILS_VERSION: "${{ matrix.rails_version }}"
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        env:
+          RAILS_VERSION: "${{ matrix.rails_version }}"
+      - name: Install Graphviz
+        run: sudo apt-get install graphviz
+      - name: Run tests
+        run: bundle exec rspec
+        env:
+          REDIS_URL: redis://localhost:6379/1
+          RAILS_VERSION: "${{ matrix.rails_version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test.rb
 dump.rdb
 .ruby-version
 .ruby-gemset
+.idea

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -3,21 +3,21 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name          = "gush"
-  spec.version       = "2.1.0"
-  spec.authors       = ["Piotrek Okoński"]
-  spec.email         = ["piotrek@okonski.org"]
-  spec.summary       = "Fast and distributed workflow runner based on ActiveJob and Redis"
-  spec.description   = "Gush is a parallel workflow runner using Redis as storage and ActiveJob for executing jobs."
-  spec.homepage      = "https://github.com/chaps-io/gush"
-  spec.license       = "MIT"
+  spec.name        = "gush"
+  spec.version     = "2.1.0"
+  spec.authors     = ["Piotrek Okoński"]
+  spec.email       = ["piotrek@okonski.org"]
+  spec.summary     = "Fast and distributed workflow runner based on ActiveJob and Redis"
+  spec.description = "Gush is a parallel workflow runner using Redis as storage and ActiveJob for executing jobs."
+  spec.homepage    = "https://github.com/chaps-io/gush"
+  spec.license     = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = "gush"
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activejob", ">= 4.2.7", "< 7.1"
+  spec.add_dependency "activejob", ">= 4.2.7", "<= 7.1.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 6"


### PR DESCRIPTION
🚀 Update GitHub Actions and gemspec for extended Rails and Ruby support

This PR updates our GitHub Actions workflow and gemspec to support newer versions of Rails and Ruby. It also includes a minor formatting change and adds JetBrains IDE configuration folder to `.gitignore`.

### Changes:
- 🧪 Extend the matrix in GitHub Actions to test against Rails versions up to `7.1.2` and exclude incompatible Ruby version combinations.
- 🛠️ Adjust formatting in the workflow file for consistency.
- 📦 Update `gush.gemspec` to allow `activejob` dependency up to version `7.1.2`.
- 🙈 Add `.idea` folder to `.gitignore` to prevent JetBrains IDE configuration files from being tracked.

### Testing:
- Ensure that the GitHub Actions workflow runs successfully with the new matrix configurations.
- Verify that the gem still functions as expected with the updated `activejob` dependency range.

By expanding the support for newer Rails and Ruby versions, we aim to keep the project up-to-date with the latest developments in the Ruby on Rails ecosystem.