### PR TITLE
Update gush dependencies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,7 +29,7 @@ jobs:
         rails_version: ['6.1.0', '7.0', '7.1.0']
         ruby-version: ['3.0', '3.1', '3.2', '3.3']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,33 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails_version: ['4.2.7', '5.1.0', '5.2.0', '6.0.0', '6.1.0', '7.0']
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
-        exclude:
-          - ruby-version: '3.0'
-            rails_version: '4.2.7'
-          - ruby-version: '3.1'
-            rails_version: '4.2.7'
-          - ruby-version: '3.0'
-            rails_version: '5.0'
-          - ruby-version: '3.1'
-            rails_version: '5.0'
-          - ruby-version: '3.0'
-            rails_version: '5.1'
-          - ruby-version: '3.1'
-            rails_version: '5.1'
-          - ruby-version: '3.0'
-            rails_version: '5.2'
-          - ruby-version: '3.1'
-            rails_version: '5.2'
-          - ruby-version: '3.0'
-            rails_version: '6.0'
-          - ruby-version: '3.1'
-            rails_version: '6.0'
-          - ruby-version: '3.1'
-            rails_version: '6.1'
-          - ruby-version: '2.6'
-            rails_version: '7.0'
+        rails_version: ['6.1.0', '7.0', '7.1.0']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -2,9 +2,11 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require_relative 'lib/gush/version'
+
 Gem::Specification.new do |spec|
   spec.name          = "gush"
-  spec.version       = "2.1.0"
+  spec.version       = Gush::VERSION
   spec.authors       = ["Piotrek Okoński"]
   spec.email         = ["piotrek@okonski.org"]
   spec.summary       = "Fast and distributed workflow runner based on ActiveJob and Redis"

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -7,8 +7,8 @@ require_relative 'lib/gush/version'
 Gem::Specification.new do |spec|
   spec.name          = "gush"
   spec.version       = Gush::VERSION
-  spec.authors       = ["Piotrek Okoński"]
-  spec.email         = ["piotrek@okonski.org"]
+  spec.authors       = ["Piotrek Okoński", "Michał Krzyżanowski"]
+  spec.email         = ["piotrek@okonski.org", "michal.krzyzanowski+github@gmail.com"]
   spec.summary       = "Fast and distributed workflow runner based on ActiveJob and Redis"
   spec.description   = "Gush is a parallel workflow runner using Redis as storage and ActiveJob for executing jobs."
   spec.homepage      = "https://github.com/chaps-io/gush"

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activejob", ">= 4.2.7", "< 7.1"
+  spec.add_dependency "activejob", ">= 6.1.0", "<= 7.1"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 6"

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.add_dependency "activejob", ">= 6.1.0", "<= 7.1"
+  spec.add_dependency "activejob", ">= 6.1.0", "~> 7.1"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 6"
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", ">= 0.19", "< 1.3"
   spec.add_dependency "launchy", "~> 2.4"
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.4"
+  spec.add_development_dependency "rake", "~> 12"
   spec.add_development_dependency "rspec", '~> 3.0'
   spec.add_development_dependency "pry", '~> 0.10'
 end

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = "gush"
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.add_dependency "activejob", ">= 6.1.0", "<= 7.1"
   spec.add_dependency "concurrent-ruby", "~> 1.0"

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.add_dependency "activejob", ">= 6.1.0", "~> 7.1"
+  spec.add_dependency "activejob", ">= 6.1.0", "< 7.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 6"

--- a/lib/gush/version.rb
+++ b/lib/gush/version.rb
@@ -1,0 +1,3 @@
+module Gush
+  VERSION = '2.1.0'
+end

--- a/lib/gush/version.rb
+++ b/lib/gush/version.rb
@@ -1,3 +1,3 @@
 module Gush
-  VERSION = '2.2.0'
+  VERSION = '3.0.0'
 end

--- a/lib/gush/version.rb
+++ b/lib/gush/version.rb
@@ -1,3 +1,3 @@
 module Gush
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -5,9 +5,10 @@ describe "Workflows" do
   context "when all jobs finish successfuly" do
     it "marks workflow as completed" do
       flow = TestWorkflow.create
-      perform_enqueued_jobs do
-        flow.start!
-      end
+
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+      flow.start!
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
 
       flow = flow.reload
       expect(flow).to be_finished

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/testing/time_helpers'
 require 'gush'
 require 'json'


### PR DESCRIPTION
This PR introduces following changes:

- Drop support for EOL ruby versions: now at least ruby 3.0.0 is required
- Drop support for EOL rails versions: at least rails 6.1.0 is required
- small patch for integration tests