### PR TITLE
Add Gush::Job#skip! (refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Add `Gush::Job#skip!` that marks a job as `#skipped?` and skips the remaining code. [See pull request](https://github.com/chaps-io/gush/pull/66).
+
 ## 2.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -383,6 +383,25 @@ class NotifyWorkflow < Gush::Workflow
 end
 ```
 
+### Skipping a Job
+
+Sometimes you'd like to skip a job, which doesn't mean that job/workflow has failed. You can call `self.skip!` inside the job to mark it as a `skipped`:
+
+```ruby
+class ProcessUserJob < Gush::Job
+  def perform
+    user = User.find params[:id]
+
+    self.skip! if user.processed?
+
+    # Code beneath here will not be called anymore
+    # and the job will be marked as 'skipped'
+    # 
+    # The workflow will continue on normally to the other jobs
+  end
+end
+```
+
 ## Command line interface (CLI)
 
 ### Checking status

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -68,6 +68,11 @@ module Gush
       @finished_at = @failed_at = current_timestamp
     end
 
+    def skip!
+      @finished_at = @skipped_at = current_timestamp
+      throw(:skipped_job)
+    end
+
     def enqueued?
       !enqueued_at.nil?
     end

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -1,8 +1,9 @@
 module Gush
   class Job
     attr_accessor :workflow_id, :incoming, :outgoing, :params,
-      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads, 
-      :klass, :queue, :wait 
+      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads,
+      :klass, :queue, :wait, :skipped_at
+
     attr_reader :id, :klass, :output_payload, :params
 
     def initialize(opts = {})
@@ -20,6 +21,7 @@ module Gush
         finished_at: finished_at,
         enqueued_at: enqueued_at,
         started_at: started_at,
+        skipped_at: skipped_at,
         failed_at: failed_at,
         params: params,
         workflow_id: workflow_id,
@@ -72,6 +74,10 @@ module Gush
 
     def finished?
       !finished_at.nil?
+    end
+
+    def skipped?
+      !skipped_at.nil?
     end
 
     def failed?
@@ -128,6 +134,7 @@ module Gush
       @workflow_id    = opts[:workflow_id]
       @queue          = opts[:queue]
       @wait           = opts[:wait]
+      @skipped_at     = opts[:skipped_at]
     end
   end
 end

--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -18,7 +18,9 @@ module Gush
 
       mark_as_started
       begin
-        job.perform
+        catch(:skipped_job) do
+          job.perform
+        end
       rescue StandardError => error
         mark_as_failed
         raise error

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -243,4 +243,49 @@ describe "Workflows" do
     expect(flow).to be_finished
     expect(flow).to_not be_failed
   end
+
+  context 'when one of the jobs is skipped' do
+    it 'still runs the rest of the jobs in the workflow' do
+      SKIPPED_SPY = double()
+
+      class FirstJob < Gush::Job
+        def perform
+          SKIPPED_SPY.foo
+        end
+      end
+
+      class SkippedJob < Gush::Job
+        def perform
+          self.skip!
+          SKIPPED_SPY.bar
+        end
+      end
+
+      class FinalJob < Gush::Job
+        def perform
+          SKIPPED_SPY.baz
+        end
+      end
+
+      class PartiallySkippedWorkflow < Gush::Workflow
+        def configure
+          run FirstJob
+          run SkippedJob, after: FirstJob
+          run FinalJob, after: SkippedJob
+        end
+      end
+
+      flow = PartiallySkippedWorkflow.create
+      flow.start!
+
+      expect(SKIPPED_SPY).to receive(:foo)
+      perform_one
+
+      expect(SKIPPED_SPY).not_to receive(:bar)
+      perform_one
+
+      expect(SKIPPED_SPY).to receive(:baz)
+      perform_one
+    end
+  end
 end

--- a/spec/gush/job_spec.rb
+++ b/spec/gush/job_spec.rb
@@ -9,12 +9,25 @@ describe Gush::Job do
       expect(job.output_payload).to eq("something")
     end
   end
+
   describe "#fail!" do
     it "sets finished and failed to true and records time" do
       job = described_class.new(name: "a-job")
       job.fail!
       expect(job.failed_at).to eq(Time.now.to_i)
       expect(job.failed?).to eq(true)
+      expect(job.finished?).to eq(true)
+      expect(job.running?).to eq(false)
+      expect(job.enqueued?).to eq(false)
+    end
+  end
+
+  describe "#skip!" do
+    it "sets finished and skipped to true and records time" do
+      job = described_class.new(name: "a-job")
+      expect { job.skip! }.to throw_symbol(:skipped_job)
+      expect(job.skipped_at).to eq(Time.now.to_i)
+      expect(job.skipped?).to eq(true)
       expect(job.finished?).to eq(true)
       expect(job.running?).to eq(false)
       expect(job.enqueued?).to eq(false)

--- a/spec/gush/job_spec.rb
+++ b/spec/gush/job_spec.rb
@@ -78,6 +78,7 @@ describe Gush::Job do
           outgoing: [],
           failed_at: nil,
           started_at: nil,
+          skipped_at: nil,
           finished_at: 123,
           enqueued_at: 120,
           params: {},

--- a/spec/gush/worker_spec.rb
+++ b/spec/gush/worker_spec.rb
@@ -33,6 +33,33 @@ describe Gush::Worker do
       end
     end
 
+    context "when job is skipped" do
+      it "should skip the rest of the code" do
+        class SkippedJob < Gush::Job
+          def perform
+            self.skip!
+            output = "Hello"
+          end
+        end
+
+        class NormalWorkflow < Gush::Workflow
+          def configure
+            run SkippedJob
+          end
+        end
+
+        workflow = NormalWorkflow.create
+
+        subject.perform(workflow.id, "SkippedJob")
+        job = client.find_job(workflow.id, "SkippedJob")
+
+        expect(job).to be_skipped
+        expect(job).to be_finished
+        expect(job.output_payload).not_to eq "Hello"
+        expect(job.output_payload).to be_nil
+      end
+    end
+
     context "when job completes successfully" do
       it "should mark it as succedeed" do
         expect(subject).to receive(:mark_as_finished)


### PR DESCRIPTION
I went ahead and refreshed @ace-subido's original PR (https://github.com/chaps-io/gush/pull/66) with his permission.  He did the heavy lifting, so props to him, I just added the integration spec requested by @pokonski and merged in the latest master.

From the original discussion in https://github.com/chaps-io/gush/issues/65 I gather there was some divergence of opinions on just what the semantics should be for the `skipped` state.  Personally  I think there is a clear space for a state that involves halting execution of a Job within a Workflow but not the Workflow itself (ie not `failed`).

I also can see the reason for thinking that there is a generalization of this semantic to more of the Workflow lifecycle (ie `skip_remaining!` as some suggested).  I have noodled a bit on this idea and have some initially attempts that I think might get somewhere but I think it might be worth getting this more Job specific skip method in first.

Welcome all feedback of course!