### PR TITLE
add missing json attribute to Gush::Job

### DIFF
--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -1,8 +1,8 @@
 module Gush
   class Job
     attr_accessor :workflow_id, :incoming, :outgoing, :params,
-      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads, 
-      :klass, :queue, :wait 
+      :finished_at, :failed_at, :started_at, :enqueued_at, :payloads,
+      :klass, :queue, :wait
     attr_reader :id, :klass, :output_payload, :params
 
     def initialize(opts = {})
@@ -23,7 +23,8 @@ module Gush
         failed_at: failed_at,
         params: params,
         workflow_id: workflow_id,
-        output_payload: output_payload
+        output_payload: output_payload,
+        wait: wait
       }
     end
 

--- a/spec/gush/job_spec.rb
+++ b/spec/gush/job_spec.rb
@@ -70,7 +70,13 @@ describe Gush::Job do
   describe "#as_json" do
     context "finished and enqueued set to true" do
       it "returns correct hash" do
-        job = described_class.new(workflow_id: 123, id: "702bced5-bb72-4bba-8f6f-15a3afa358bd", finished_at: 123, enqueued_at: 120)
+        job = described_class.new(
+          workflow_id: 123,
+          id: '702bced5-bb72-4bba-8f6f-15a3afa358bd',
+          finished_at: 123,
+          enqueued_at: 120,
+          wait: 300
+        )
         expected = {
           id: '702bced5-bb72-4bba-8f6f-15a3afa358bd',
           klass: "Gush::Job",
@@ -83,7 +89,8 @@ describe Gush::Job do
           params: {},
           queue: nil,
           output_payload: nil,
-          workflow_id: 123
+          workflow_id: 123,
+          wait: 300
         }
         expect(job.as_json).to eq(expected)
       end


### PR DESCRIPTION
Just added missing :wait attribute to Gush::Job#as_json because that argument was skipped when Gush::Job#persist_job called so sidekiq job was performed with no delay even if :wait was specified