### PR TITLE
Added rubocop for code style consistency

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,6 +39,10 @@ jobs:
         RAILS_VERSION: "${{ matrix.rails_version }}"
     - name: Install Graphviz
       run: sudo apt-get install graphviz
+    - name: Run code lint
+      run: bundle exec rubocop
+      env:
+        RAILS_VERSION: "${{ matrix.rails_version }}"
     - name: Run tests
       run: bundle exec rspec
       env:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,19 +87,19 @@ Lint/UselessAssignment:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 32
+  Enabled: false
 
 Metrics/BlockLength:
-  Max: 195
+  Enabled: false
 
 Metrics/ClassLength:
-  Max: 170
+  Enabled: false
 
 Metrics/CyclomaticComplexity:
-  Max: 8
+  Enabled: false
 
 Metrics/MethodLength:
-  Max: 23
+  Enabled: false
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
@@ -198,7 +198,7 @@ Style/WordArray:
   Enabled: false
 
 Layout/LineLength:
-  Max: 156
+  Enabled: false
 
 RSpec/AnyInstance:
   Enabled: false
@@ -222,7 +222,7 @@ RSpec/EmptyLineAfterSubject:
   Enabled: false
 
 RSpec/ExampleLength:
-  Max: 34
+  Enabled: false
 
 RSpec/ExampleWording:
   Enabled: false
@@ -246,16 +246,16 @@ RSpec/MessageSpies:
   EnforcedStyle: receive
 
 RSpec/MultipleExpectations:
-  Max: 16
+  Enabled: false
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 6
+  Enabled: false
 
 RSpec/NamedSubject:
   Enabled: false
 
 RSpec/NestedGroups:
-  Max: 4
+  Enabled: false
 
 RSpec/NotToNot:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,279 @@
+require:
+  - rubocop-rake
+  - rubocop-rspec
+
+AllCops:
+  NewCops: disable
+
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+Layout/ArgumentAlignment:
+  Enabled: false
+
+Layout/CaseIndentation:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/FirstHashElementIndentation:
+  Enabled: false
+
+Layout/HashAlignment:
+  Enabled: false
+
+Layout/SpaceAfterMethodName:
+  Enabled: false
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: false
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
+Layout/TrailingWhitespace:
+  Enabled: false
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+
+Lint/DuplicateMethods:
+  Enabled: false
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Lint/RedundantSplatExpansion:
+  Enabled: false
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+
+Lint/ToJSON:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/UselessAssignment:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 32
+
+Metrics/BlockLength:
+  Max: 195
+
+Metrics/ClassLength:
+  Max: 170
+
+Metrics/CyclomaticComplexity:
+  Max: 8
+
+Metrics/MethodLength:
+  Max: 23
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Naming/PredicateName:
+  Enabled: false
+
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/ClassVars:
+  Enabled: false
+
+Style/ColonMethodCall:
+  Enabled: false
+
+Style/CombinableLoops:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyCaseCondition:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/Encoding:
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/GlobalStdStream:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/HashSyntax:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/InverseMethods:
+  Enabled: false
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NumericLiteralPrefix:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Style/SelfAssignment:
+  Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/StderrPuts:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/SymbolProc:
+  Enabled: false
+
+Style/UnlessElse:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 156
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/BeEq:
+  Enabled: false
+
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false
+
+RSpec/EmptyExampleGroup:
+  Enabled: false
+
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: false
+
+RSpec/EmptyLineAfterSubject:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Max: 34
+
+RSpec/ExampleWording:
+  Enabled: false
+
+RSpec/ExpectChange:
+  Enabled: false
+
+RSpec/HookArgument:
+  EnforcedStyle: each
+
+RSpec/LeakyConstantDeclaration:
+  Enabled: false
+
+RSpec/LetSetup:
+  Enabled: false
+
+RSpec/MatchArray:
+  Enabled: false
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
+RSpec/MultipleExpectations:
+  Max: 16
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 6
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 4
+
+RSpec/NotToNot:
+  Enabled: false
+
+RSpec/PredicateMatcher:
+  Enabled: false
+
+RSpec/ReceiveCounts:
+  Enabled: false
+
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+RSpec/StubbedMock:
+  Enabled: false
+
+RSpec/SubjectStub:
+  Enabled: false
+
+RSpec/VerifiedDoubles:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,15 +14,6 @@ Layout/ArgumentAlignment:
 Layout/CaseIndentation:
   Enabled: false
 
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
-Layout/EmptyLineAfterMagicComment:
-  Enabled: false
-
-Layout/EmptyLinesAroundAccessModifier:
-  Enabled: false
-
 Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 
@@ -33,9 +24,6 @@ Layout/FirstHashElementIndentation:
   Enabled: false
 
 Layout/HashAlignment:
-  Enabled: false
-
-Layout/SpaceAfterMethodName:
   Enabled: false
 
 Layout/SpaceAroundEqualsInParameterDefault:
@@ -53,25 +41,11 @@ Layout/SpaceInsideBlockBraces:
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
-Layout/TrailingWhitespace:
-  Enabled: false
-
-Lint/AmbiguousBlockAssociation:
-  Enabled: false
-
 Lint/ConstantDefinitionInBlock:
-  Enabled: false
-
-Lint/DuplicateMethods:
-  Enabled: false
-
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: false
+  Exclude:
+    - spec/**/*
 
 Lint/RedundantSplatExpansion:
-  Enabled: false
-
-Lint/ShadowingOuterLocalVariable:
   Enabled: false
 
 Lint/ToJSON:
@@ -116,9 +90,6 @@ Style/BlockDelimiters:
 Style/ClassVars:
   Enabled: false
 
-Style/ColonMethodCall:
-  Enabled: false
-
 Style/CombinableLoops:
   Enabled: false
 
@@ -134,16 +105,7 @@ Style/EmptyCaseCondition:
 Style/EmptyMethod:
   Enabled: false
 
-Style/Encoding:
-  Enabled: false
-
-Style/ExpandPathArguments:
-  Enabled: false
-
 Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/GlobalStdStream:
   Enabled: false
 
 Style/GuardClause:
@@ -161,9 +123,6 @@ Style/InverseMethods:
 Style/MethodCallWithoutArgsParentheses:
   Enabled: false
 
-Style/MutableConstant:
-  Enabled: false
-
 Style/NumericLiteralPrefix:
   Enabled: false
 
@@ -176,13 +135,7 @@ Style/RaiseArgs:
 Style/SafeNavigation:
   Enabled: false
 
-Style/SelfAssignment:
-  Enabled: false
-
 Style/SpecialGlobalVars:
-  Enabled: false
-
-Style/StderrPuts:
   Enabled: false
 
 Style/StringLiterals:

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -33,6 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "launchy", "~> 2.4"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12"
+  spec.add_development_dependency "rubocop", '~> 1.65.0'
+  spec.add_development_dependency "rubocop-rake", '~> 0.6.0'
+  spec.add_development_dependency "rubocop-rspec", '~> 3.0.3'
   spec.add_development_dependency "rspec", '~> 3.0'
   spec.add_development_dependency "pry", '~> 0.10'
 end

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require_relative 'lib/gush/version'

--- a/lib/gush/cli.rb
+++ b/lib/gush/cli.rb
@@ -101,7 +101,7 @@ module Gush
         begin
           workflow = class_or_id.constantize.new
         rescue NameError => e
-          STDERR.puts Paint["'#{class_or_id}' is not a valid workflow class or id", :red]
+          warn Paint["'#{class_or_id}' is not a valid workflow class or id", :red]
           exit 1
         end
       end

--- a/lib/gush/cli/overview.rb
+++ b/lib/gush/cli/overview.rb
@@ -34,6 +34,7 @@ module Gush
       end
 
       private
+
       def rows
         [].tap do |rows|
           columns.each_pair do |name, value|
@@ -91,6 +92,7 @@ module Gush
 
       def jobs_by_type(type)
         return sorted_jobs if type == :all
+
         jobs.select{|j| j.public_send("#{type}?") }
       end
 

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -95,7 +95,7 @@ module Gush
         keys = redis.scan_each(match: "gush.jobs.#{id}.*")
 
         nodes = keys.each_with_object([]) do |key, array|
-          array.concat redis.hvals(key).map { |json| Gush::JSON.decode(json, symbolize_keys: true) }
+          array.concat(redis.hvals(key).map { |json| Gush::JSON.decode(json, symbolize_keys: true) })
         end
 
         workflow_from_hash(hash, nodes)
@@ -142,13 +142,13 @@ module Gush
     end
 
     def expire_workflow(workflow, ttl=nil)
-      ttl = ttl || configuration.ttl
+      ttl ||= configuration.ttl
       redis.expire("gush.workflows.#{workflow.id}", ttl)
       workflow.jobs.each {|job| expire_job(workflow.id, job, ttl) }
     end
 
     def expire_job(workflow_id, job, ttl=nil)
-      ttl = ttl || configuration.ttl
+      ttl ||= configuration.ttl
       redis.expire("gush.jobs.#{workflow_id}.#{job.klass}", ttl)
     end
 

--- a/lib/gush/graph.rb
+++ b/lib/gush/graph.rb
@@ -4,7 +4,7 @@ require 'tmpdir'
 
 module Gush
   class Graph
-    attr_reader :workflow, :filename, :path, :start_node, :end_node
+    attr_reader :workflow, :filename, :start_node, :end_node
 
     def initialize(workflow, options = {})
       @workflow = workflow
@@ -32,7 +32,7 @@ module Gush
       file_format = path.split('.')[-1]
       format = file_format if file_format.length == 3
 
-      Graphviz::output(@graph, path: path, format: format)
+      Graphviz.output(@graph, path: path, format: format)
     end
 
     def path

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -3,7 +3,7 @@ module Gush
     attr_accessor :workflow_id, :incoming, :outgoing, :params,
       :finished_at, :failed_at, :started_at, :enqueued_at, :payloads,
       :klass, :queue, :wait
-    attr_reader :id, :klass, :output_payload, :params
+    attr_reader :id, :output_payload
 
     def initialize(opts = {})
       options = opts.dup

--- a/lib/gush/version.rb
+++ b/lib/gush/version.rb
@@ -1,3 +1,3 @@
 module Gush
-  VERSION = '3.0.0'
+  VERSION = '3.0.0'.freeze
 end

--- a/lib/gush/worker.rb
+++ b/lib/gush/worker.rb
@@ -30,7 +30,7 @@ module Gush
 
     private
 
-    attr_reader :client, :workflow_id, :job, :configuration
+    attr_reader :workflow_id, :job
 
     def client
       @client ||= Gush::Client.new(Gush.configuration)

--- a/lib/gush/workflow.rb
+++ b/lib/gush/workflow.rb
@@ -2,7 +2,8 @@ require 'securerandom'
 
 module Gush
   class Workflow
-    attr_accessor :id, :jobs, :dependencies, :stopped, :persisted, :arguments, :kwargs, :globals
+    attr_accessor :jobs, :dependencies, :stopped, :persisted, :arguments, :kwargs, :globals
+    attr_writer :id
 
     def initialize(*args, globals: nil, internal_state: {}, **kwargs)
       @arguments = args
@@ -56,7 +57,7 @@ module Gush
       client.persist_workflow(self)
     end
 
-    def expire! (ttl=nil)
+    def expire!(ttl=nil)
       client.expire_workflow(self, ttl)
     end
 

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -136,7 +136,7 @@ describe "Workflows" do
 
     class SummaryJob < Gush::Job
       def perform
-        output payloads.map { |payload| payload[:output] }
+        output(payloads.map { |payload| payload[:output] })
       end
     end
 

--- a/spec/gush/workflow_spec.rb
+++ b/spec/gush/workflow_spec.rb
@@ -41,7 +41,7 @@ describe Gush::Workflow do
         jobs: flow.jobs,
         dependencies: flow.dependencies,
         persisted: true,
-        stopped: true,
+        stopped: true
       }
 
       flow_copy = TestWorkflow.new(internal_state: internal_state)
@@ -61,20 +61,9 @@ describe Gush::Workflow do
         end
       end
 
-      expect(INTERNAL_SETUP_SPY).to receive(:some_method).never
+      expect(INTERNAL_SETUP_SPY).not_to receive(:some_method)
 
       flow = TestWorkflow.new(internal_state: { needs_setup: false })
-    end
-  end
-
-  describe "#status" do
-    context "when failed" do
-      it "returns :failed" do
-        flow = TestWorkflow.create
-        flow.find_job("Prepare").fail!
-        flow.persist!
-        expect(flow.reload.status).to eq(:failed)
-      end
     end
   end
 
@@ -132,22 +121,35 @@ describe Gush::Workflow do
   end
 
   describe "#status" do
+    context "when failed" do
+      it "returns :failed" do
+        flow = TestWorkflow.create
+        flow.find_job("Prepare").fail!
+        flow.persist!
+        expect(flow.reload.status).to eq(:failed)
+      end
+    end
+
     it "returns failed" do
       subject.find_job('Prepare').fail!
       expect(subject.status).to eq(:failed)
     end
+
     it "returns running" do
       subject.find_job('Prepare').start!
       expect(subject.status).to eq(:running)
     end
+
     it "returns finished" do
       subject.jobs.each {|n| n.finish! }
       expect(subject.status).to eq(:finished)
     end
+
     it "returns stopped" do
       subject.stopped = true
       expect(subject.status).to eq(:stopped)
     end
+
     it "returns pending" do
       expect(subject.status).to eq(:pending)
     end
@@ -175,7 +177,7 @@ describe Gush::Workflow do
           "stopped" => false,
           "dependencies" => [{
             "from" => "FetchFirstJob",
-            "to" => job_with_id("PersistFirstJob"),
+            "to" => job_with_id("PersistFirstJob")
           }],
           "arguments" => ["arg1", "arg2"],
           "kwargs" => {"arg3" => 123},
@@ -196,21 +198,21 @@ describe Gush::Workflow do
       flow = Gush::Workflow.new
       flow.run(Gush::Job, params: { something: 1 })
       flow.save
-      expect(flow.jobs.first.params).to eq ({ something: 1 })
+      expect(flow.jobs.first.params).to eq({ something: 1 })
     end
 
     it "merges globals with params and passes them to the job, with job param taking precedence" do
       flow = Gush::Workflow.new(globals: { something: 2, global1: 123 })
       flow.run(Gush::Job, params: { something: 1 })
       flow.save
-      expect(flow.jobs.first.params).to eq ({ something: 1, global1: 123 })
+      expect(flow.jobs.first.params).to eq({ something: 1, global1: 123 })
     end
 
     it "allows passing wait param to the job" do
       flow = Gush::Workflow.new
       flow.run(Gush::Job, wait: 5.seconds)
       flow.save
-      expect(flow.jobs.first.wait).to eq (5.seconds)
+      expect(flow.jobs.first.wait).to eq(5.seconds)
     end
 
     context "when graph is empty" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,11 +120,11 @@ RSpec.configure do |config|
     clear_enqueued_jobs
     clear_performed_jobs
 
-    Gush.configure do |config|
-      config.redis_url        = REDIS_URL
-      config.gushfile         = GUSHFILE
-      config.locking_duration = defined?(locking_duration) ? locking_duration : 2
-      config.polling_interval = defined?(polling_interval) ? polling_interval : 0.3
+    Gush.configure do |c|
+      c.redis_url        = REDIS_URL
+      c.gushfile         = GUSHFILE
+      c.locking_duration = defined?(locking_duration) ? locking_duration : 2
+      c.polling_interval = defined?(polling_interval) ? polling_interval : 0.3
     end
   end
 


### PR DESCRIPTION
This PR includes three commits (that can be squashed before merging):

1. Added rubocop (and related gems) and autogenerated a config file that matches enabled cops to the existing code style. Also added rubocop step to GitHub actions.
2. Manually disabled a few cops that depend on arbitrarily chosen lengths (e.g. `Metrics/MethodLength`).
3. Enabled some cops and fixed related warnings.

For the last commit, I chose cops that were very easy to update the code to adhere to and, in some cases, relate to preventing bugs. I mostly avoided cops that involve more personal code style preferences (e.g. spacing, alignment, naming). If those changes don't follow this project's preferred styling, I'm happy to roll some or all of them back.