### PR TITLE
Fix workflow status when the workflow is pending to start

### DIFF
--- a/lib/gush/workflow.rb
+++ b/lib/gush/workflow.rb
@@ -159,7 +159,7 @@ module Gush
         when stopped?
           :stopped
         else
-          :running
+          :pending
       end
     end
 

--- a/spec/gush/workflow_spec.rb
+++ b/spec/gush/workflow_spec.rb
@@ -98,6 +98,28 @@ describe Gush::Workflow do
     end
   end
 
+  describe "#status" do
+    it "returns failed" do
+      subject.find_job('Prepare').fail!
+      expect(subject.status).to eq(:failed)
+    end
+    it "returns running" do
+      subject.find_job('Prepare').start!
+      expect(subject.status).to eq(:running)
+    end
+    it "returns finished" do
+      subject.jobs.each {|n| n.finish! }
+      expect(subject.status).to eq(:finished)
+    end
+    it "returns stopped" do
+      subject.stopped = true
+      expect(subject.status).to eq(:stopped)
+    end
+    it "returns pending" do
+      expect(subject.status).to eq(:pending)
+    end
+  end
+
   describe "#to_json" do
     it "returns correct hash" do
       klass = Class.new(Gush::Workflow) do
@@ -112,7 +134,7 @@ describe Gush::Workflow do
           "id" => an_instance_of(String),
           "name" => klass.to_s,
           "klass" => klass.to_s,
-          "status" => "running",
+          "status" => "pending",
           "total" => 2,
           "finished" => 0,
           "started_at" => nil,


### PR DESCRIPTION
Update default workflow status to pending when workflow is pending to start

This implements the same change as #89, with specs added.