### PR TITLE
`Gush::Client` now delegates the `ActiveJob.perform_later` call to `Gush::Job`

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,37 @@ class NotifyWorkflow < Gush::Workflow
 end
 ```
 
+### Customization of ActiveJob enqueueing
+
+There might be a case when you want to customize enqueing a job with more than just the above two options (`queue` and `wait`).
+
+To pass additional options to `ActiveJob.set`, override `Job#worker_options`, e.g.:
+
+```ruby
+
+class ScheduledJob < Gush::Job
+
+  def worker_options
+    super.merge(wait_until: Time.at(params[:start_at]))
+  end
+
+end
+```
+
+Or to entirely customize the ActiveJob integration, override `Job#enqueue_worker!`, e.g.:
+
+```ruby
+
+class SynchronousJob < Gush::Job
+
+  def enqueue_worker!(options = {})
+    Gush::Worker.perform_now(workflow_id, name)
+  end
+
+end
+```
+
+
 ## Command line interface (CLI)
 
 ### Checking status

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -155,14 +155,9 @@ module Gush
     def enqueue_job(workflow_id, job)
       job.enqueue!
       persist_job(workflow_id, job)
-      queue = job.queue || configuration.namespace
-      wait = job.wait
-      
-      if wait.present?
-        Gush::Worker.set(queue: queue, wait: wait).perform_later(*[workflow_id, job.name])
-      else
-        Gush::Worker.set(queue: queue).perform_later(*[workflow_id, job.name])
-      end
+
+      options = { queue: configuration.namespace }.merge(job.worker_options)
+      job.enqueue_worker!(options)
     end
 
     private

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -59,6 +59,14 @@ module Gush
       @failed_at = nil
     end
 
+    def enqueue_worker!(options = {})
+      Gush::Worker.set(options).perform_later(workflow_id, name)
+    end
+
+    def worker_options
+      { queue: queue, wait: wait }.compact
+    end
+
     def finish!
       @finished_at = current_timestamp
     end


### PR DESCRIPTION
This delegation allows for Gush users to easily override the enqueing behavior to their custom job class, e.g. to support additional ActiveJob options or enqueing behaviors (e.g synchronous with `perform_now`).