### PR TITLE
Persist dependencies so that `Workflow#configure` is not required on load

### DIFF
--- a/lib/gush/workflow.rb
+++ b/lib/gush/workflow.rb
@@ -2,19 +2,20 @@ require 'securerandom'
 
 module Gush
   class Workflow
-    attr_accessor :id, :jobs, :stopped, :persisted, :arguments, :kwargs, :globals
+    attr_accessor :id, :jobs, :dependencies, :stopped, :persisted, :arguments, :kwargs, :globals
 
-    def initialize(*args, globals: nil, **kwargs)
-      @id = id
-      @jobs = []
-      @dependencies = []
-      @persisted = false
-      @stopped = false
+    def initialize(*args, globals: nil, internal_state: {}, **kwargs)
       @arguments = args
       @kwargs = kwargs
       @globals = globals || {}
 
-      setup
+      @id = internal_state[:id] || id
+      @jobs = internal_state[:jobs] || []
+      @dependencies = internal_state[:dependencies] || []
+      @persisted = internal_state[:persisted] || false
+      @stopped = internal_state[:stopped] || false
+
+      setup unless internal_state[:skip_setup]
     end
 
     def self.find(id)
@@ -179,6 +180,7 @@ module Gush
         arguments: @arguments,
         kwargs: @kwargs,
         globals: @globals,
+        dependencies: @dependencies,
         total: jobs.count,
         finished: jobs.count(&:finished?),
         klass: name,

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -169,8 +169,8 @@ describe "Workflows" do
     INTERNAL_CONFIGURE_SPY = double('configure spy')
     expect(INTERNAL_SPY).to receive(:some_method).exactly(110).times
 
-    # One time when persisting, second time when reloading in the spec
-    expect(INTERNAL_CONFIGURE_SPY).to receive(:some_method).exactly(2).times
+    # One time when persisting; reloading does not call configure again
+    expect(INTERNAL_CONFIGURE_SPY).to receive(:some_method).exactly(1).time
 
     class SimpleJob < Gush::Job
       def perform

--- a/spec/gush/client_spec.rb
+++ b/spec/gush/client_spec.rb
@@ -19,9 +19,12 @@ describe Gush::Client do
       it "returns Workflow object" do
         expected_workflow = TestWorkflow.create
         workflow = client.find_workflow(expected_workflow.id)
+        dependencies = workflow.dependencies
 
         expect(workflow.id).to eq(expected_workflow.id)
+        expect(workflow.persisted).to eq(true)
         expect(workflow.jobs.map(&:name)).to match_array(expected_workflow.jobs.map(&:name))
+        expect(workflow.dependencies).to eq(dependencies)
       end
 
       context "when workflow has parameters" do


### PR DESCRIPTION
Previously, `Workflow#configure` was called every time a Workflow was instantiated. This could create broken dependency graphs, e.g. if a configure method sets up job dependencies based on some mutable data like a timestamp argument or a database value.

Instead, serialize workflow dependencies along with the rest of a workflow's data and reload it via `Client#workflow_from_hash` and tell `Workflow#initialize` not to run setup/configure.

Note that for backwards compatibility with workflows persisted before this change, the setup method will still be called if dependencies in the deserialized hash are nil.