### PR TITLE
Client#page return valid results if old job/worker class no longer exists

### DIFF
--- a/lib/gush/cli.rb
+++ b/lib/gush/cli.rb
@@ -74,9 +74,7 @@ module Gush
     option :start, type: :numeric, default: nil
     option :stop, type: :numeric, default: nil
     def list(start=nil, stop=nil)
-      workflows = client.workflow_ids(start, stop).map do |id|
-        client.find_workflow(id)
-      end
+      workflows = client.workflows(start, stop)
 
       rows = workflows.map do |workflow|
         [workflow.id, (Time.at(workflow.started_at) if workflow.started_at), workflow.class, {alignment: :center, value: status_for(workflow)}]

--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -104,7 +104,11 @@ module Gush
     end
 
     def workflows(start=nil, stop=nil, **kwargs)
-      workflow_ids(start, stop, **kwargs).map { |id| find_workflow(id) }
+      workflow_ids(start, stop, **kwargs).map do |id|
+        find_workflow(id)
+        rescue WorkflowClassDoesNotExist, JobClassDoesNotExist
+          nil
+      end.compact
     end
 
     def workflows_count
@@ -285,6 +289,8 @@ module Gush
         globals: hash[:globals],
         internal_state: internal_state
       )
+    rescue NameError
+      raise WorkflowClassDoesNotExist.new("Workflow #{hash[:klass]} doesn't exist")
     end
 
     def redis

--- a/lib/gush/errors.rb
+++ b/lib/gush/errors.rb
@@ -1,4 +1,6 @@
 module Gush
   class WorkflowNotFound < StandardError; end
+  class WorkflowClassDoesNotExist < StandardError; end
+  class JobClassDoesNotExist < StandardError; end
   class DependencyLevelTooDeep < StandardError; end
 end

--- a/lib/gush/job.rb
+++ b/lib/gush/job.rb
@@ -38,6 +38,8 @@ module Gush
 
     def self.from_hash(hash)
       hash[:klass].constantize.new(hash)
+    rescue NameError
+      raise JobClassDoesNotExist.new("Job #{hash[:klass]} doesn't exist")
     end
 
     def output(data)

--- a/spec/gush/job_spec.rb
+++ b/spec/gush/job_spec.rb
@@ -165,5 +165,11 @@ describe Gush::Job do
       expect(job.started_at).to eq(55)
       expect(job.enqueued_at).to eq(444)
     end
+
+    it "raises JobClassDoesNotExist if the job class is no longer defined" do
+      expect {
+        described_class.from_hash({klass: 'NonExistentJob'})
+      }.to raise_error(Gush::JobClassDoesNotExist)
+    end
   end
 end


### PR DESCRIPTION

I realize now that I ran into the same issue this pr aims to fix for the CLI, https://github.com/chaps-io/gush/pull/72  

here, I opted to simply omit workflows from the `Client.workflows` list output as opposed to building a null-flavored version of the original object – I can see benefits to the above approach, but ultimately in my use case, it seems data referencing now-deleted code can be safely ignored. 
