### PR TITLE
allow thor 1.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,10 +10,10 @@ name: Ruby
 on:
   pull_request:
     paths-ignore:
-      - 'README.md'
+      - "README.md"
   push:
     paths-ignore:
-      - 'README.md'
+      - "README.md"
 
 jobs:
   test:
@@ -26,30 +26,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails_version: ['6.1.0', '7.0', '7.1.0', '7.2.2', "8.0.1"]
-        ruby_version: ['3.1', '3.2', '3.3', '3.4']
+        rails_version: ["7.0", "7.1.0", "7.2.2", "8.0.1", "8.1.0"]
+        ruby_version: ["3.1", "3.2", "3.3", "3.4"]
         exclude:
-          - ruby_version: '3.4'
-            rails_version: '6.1.0'
-          - ruby_version: '3.1'
-            rails_version: '8.0.1'
+          - ruby_version: "3.1"
+            rails_version: "8.1.0"
+          - ruby_version: "3.1"
+            rails_version: "8.0.1"
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby_version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      env:
-        RAILS_VERSION: "${{ matrix.rails_version }}"
-    - name: Install Graphviz
-      run: sudo apt-get install graphviz
-    - name: Run code lint
-      run: bundle exec rubocop
-      env:
-        RAILS_VERSION: "${{ matrix.rails_version }}"
-    - name: Run tests
-      run: bundle exec rspec
-      env:
-        REDIS_URL: redis://localhost:6379/1
-        RAILS_VERSION: "${{ matrix.rails_version }}"
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        env:
+          RAILS_VERSION: "${{ matrix.rails_version }}"
+      - name: Install Graphviz
+        run: sudo apt-get install graphviz
+      - name: Run code lint
+        run: bundle exec rubocop
+        env:
+          RAILS_VERSION: "${{ matrix.rails_version }}"
+      - name: Run tests
+        run: bundle exec rspec
+        env:
+          REDIS_URL: redis://localhost:6379/1
+          RAILS_VERSION: "${{ matrix.rails_version }}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-rails_version = ENV['RAILS_VERSION'] || '< 7.0'
+rails_version = ENV['RAILS_VERSION'] || '>= 7.0.0'
 rails_version = "~> #{rails_version}" if rails_version =~ /^\d/
 gem 'activejob', rails_version
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This README is about the latest `master` code, which might differ from what is r
 ### 1. Add `gush` to Gemfile
 
 ```ruby
-gem 'gush', '~> 4.2'
+gem 'gush', '~> 5.0'
 ```
 
 ### 2. Create `Gushfile`

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 3.0.0'
 
-  # ActiveJob 7.0 is required to maintain compatibility concurrent-ruby and ActiveSupport logger gem usage
-  # however, this allows us to upgrade thor to v1.4.0 which fixes security issues
   spec.add_dependency "activejob", ">= 7.0.0", "< 8.1.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.add_dependency "activejob", ">= 6.1.0", "< 8.1.0"
+  # ActiveJob 7.0 is required to maintain compatibility concurrent-ruby and ActiveSupport logger gem usage
+  # however, this allows us to upgrade thor to v1.4.0 which fixes security issues
+  spec.add_dependency "activejob", ">= 7.0.0", "< 8.1.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 6"
@@ -28,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "graphviz", "~> 1.2"
   spec.add_dependency "terminal-table", ">= 1.4", "< 3.1"
   spec.add_dependency "paint", "~> 2.2"
-  spec.add_dependency "thor", ">= 0.19", "< 1.3"
+  spec.add_dependency "thor", ">= 0.19", "< 1.5"
   spec.add_dependency "launchy", "~> 2.4"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12"

--- a/gush.gemspec
+++ b/gush.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.add_dependency "activejob", ">= 7.0.0", "< 8.1.0"
+  spec.add_dependency "activejob", ">= 7.0.0", "< 9"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 6"

--- a/lib/gush/version.rb
+++ b/lib/gush/version.rb
@@ -1,3 +1,3 @@
 module Gush
-  VERSION = '4.2.0'.freeze
+  VERSION = '4.2.1'.freeze
 end

--- a/lib/gush/version.rb
+++ b/lib/gush/version.rb
@@ -1,3 +1,3 @@
 module Gush
-  VERSION = '4.3.0'.freeze
+  VERSION = '5.0.0'.freeze
 end

--- a/lib/gush/version.rb
+++ b/lib/gush/version.rb
@@ -1,3 +1,3 @@
 module Gush
-  VERSION = '4.2.1'.freeze
+  VERSION = '4.3.0'.freeze
 end


### PR DESCRIPTION
Thor < 1.4 has a security issue, see: https://github.com/advisories/GHSA-mqcp-p2hv-vw6x

This address the issue: https://github.com/chaps-io/gush/issues/130

I needed to make ActiveJob minimally 7.0 in order to load the Logger properly